### PR TITLE
Adding files required for ECS build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:7
+
+RUN yum update -y && \
+  yum install -y \
+  epel-release-7 \
+  zip \
+  unzip \
+  java-11-openjdk \
+  maven \
+  make && \
+  yum clean all
+
+COPY officer-filing-api.jar /opt/officer-filing-api/
+COPY start-ecs /usr/local/bin/
+
+RUN chmod 555 /usr/local/bin/start-ecs
+
+CMD ["start-ecs"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 artifact_name       := officer-filing-api
 version             := unversioned
 
-.PHONY
+.PHONY: all
 all: build
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 artifact_name       := officer-filing-api
 version             := unversioned
 
+.PHONY
+all: build
+
 .PHONY: clean
 clean:
 	mvn clean

--- a/start-ecs
+++ b/start-ecs
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "/opt/officer-filing-api/officer-filing-api.jar"


### PR DESCRIPTION
- this is taken from the ECS guide for developers
- copied from the payments-admin-web service, with amendments:
  - changed to java-11-openjdk in Dockerfile - think correct name
  - added all target to Makefile for Dockerfile to run