### PR TITLE
Produce consistent error message format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <!--- CH -->
         <structured-logging.version>1.9.14</structured-logging.version>
+        <private-api-sdk-java.version>2.0.187</private-api-sdk-java.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -70,6 +71,11 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
         </dependency>
 
         <!-- test -->

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/ApiErrors.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/ApiErrors.java
@@ -1,0 +1,67 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import uk.gov.companieshouse.api.error.ApiError;
+
+/**
+ * Set of APIErrors.
+ */
+public class ApiErrors {
+    private final Set<ApiError> errors;
+
+    public ApiErrors() {
+        this.errors = new HashSet<>();
+    }
+
+    public ApiErrors(final Collection<ApiError> errors) {
+        this.errors = new HashSet<>(errors);
+    }
+
+    /**
+     * Add a new error to the error set.
+     *
+     * @param error the APIError
+     * @return true if error was not already present
+     */
+    public boolean add(final ApiError error) {
+        Objects.requireNonNull(error, "'error' cannot be null");
+
+        return errors.add(error);
+    }
+
+    /**
+     * Checks whether the APIError set is empty.
+     *
+     * @return false if there are no errors
+     */
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+
+    /**
+     * Checks whether the error is already present.
+     *
+     * @param error the APIError to be checked
+     * @return true if the set contains the specified error
+     */
+    public boolean contains(final ApiError error) {
+        Objects.requireNonNull(error, "'error' cannot be null");
+
+        return errors.contains(error);
+    }
+
+    public Set<ApiError> getErrors() {
+        return Collections.unmodifiableSet(errors);
+    }
+
+    @JsonIgnore
+    public int getErrorCount() {
+        return errors.size();
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/CachingFilter.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/CachingFilter.java
@@ -19,7 +19,7 @@ public class CachingFilter implements Filter {
     @Override
     public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
             final FilterChain filterChain) throws IOException, ServletException {
-        final ContentCachingRequestWrapper contentCachingRequestWrapper =
+        final var contentCachingRequestWrapper =
                 new ContentCachingRequestWrapper((HttpServletRequest) servletRequest);
         filterChain.doFilter(contentCachingRequestWrapper, servletResponse);
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/CachingFilter.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/CachingFilter.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+/**
+ * Cache the request for future use; {@link RestExceptionHandler} can include the request body
+ * content in any error response.
+ */
+@Component
+public class CachingFilter implements Filter {
+    @Override
+    public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
+            final FilterChain filterChain) throws IOException, ServletException {
+        final ContentCachingRequestWrapper contentCachingRequestWrapper =
+                new ContentCachingRequestWrapper((HttpServletRequest) servletRequest);
+        filterChain.doFilter(contentCachingRequestWrapper, servletResponse);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/ErrorType.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/ErrorType.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+/**
+ * Validation error types
+ */
+public enum ErrorType {
+
+    SERVICE("ch:service"),
+    VALIDATION("ch:validation");
+
+    private final String type;
+
+    ErrorType(final String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/InvalidFilingException.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/InvalidFilingException.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.validation.FieldError;
+
+public class InvalidFilingException extends RuntimeException {
+    private final List<FieldError> fieldErrors;
+
+    public InvalidFilingException(final List<FieldError> fieldErrors) {
+
+        this.fieldErrors = fieldErrors;
+    }
+
+    public List<FieldError> getFieldErrors() {
+        return Collections.unmodifiableList(fieldErrors);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/LocationType.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/LocationType.java
@@ -5,6 +5,7 @@ package uk.gov.companieshouse.officerfiling.api.error;
  */
 public enum LocationType {
 
+    RESOURCE("resource"),
     REQUEST_BODY("request-body"),
     JSON_PATH("json-path");
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/LocationType.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/LocationType.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+/**
+ * Validation error location types
+ */
+public enum LocationType {
+
+    REQUEST_BODY("request-body"),
+    JSON_PATH("json-path");
+
+    private final String value;
+
+    LocationType(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandler.java
@@ -1,0 +1,91 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import uk.gov.companieshouse.api.error.ApiError;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@ControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+    private static final Logger CH_LOGGER = LoggerFactory.getLogger("officer-filing-api");
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            final HttpMessageNotReadableException ex, final HttpHeaders headers,
+            final HttpStatus status, final WebRequest request) {
+
+        final ContentCachingRequestWrapper nativeRequest =
+                (ContentCachingRequestWrapper) ((ServletWebRequest) request).getNativeRequest();
+        final String requestBodyAsString = new String(nativeRequest.getContentAsByteArray());
+
+        final var cause =
+                ex.getMostSpecificCause().getMessage().replaceAll("Source: (:?[^;]*); ", "");
+        final var bodyError = buildRequestBodyError(cause, "$", null);
+
+        bodyError.addErrorValue("body", requestBodyAsString);
+
+        return ResponseEntity.status(status).body(new ApiErrors(List.of(bodyError)));
+    }
+
+    @ExceptionHandler(InvalidFilingException.class)
+    public ResponseEntity<ApiErrors> handleInvalidFilingException(final InvalidFilingException ex) {
+        final var fieldErrors = ex.getFieldErrors();
+
+        final var errorList = fieldErrors.stream()
+                .map(e -> buildRequestBodyError(e.getDefaultMessage(), getJsonPath(e),
+                        e.getRejectedValue()))
+                .collect(Collectors.toList());
+        final var errors = new ApiErrors(errorList);
+
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    private static String getJsonPath(final FieldError e) {
+        return Optional.ofNullable(e.getCodes())
+                .stream()
+                .flatMap(Arrays::stream)
+                .skip(1)
+                .findFirst()
+                .map(s -> s.replaceAll("^[^.]*", "\\$"))
+                .orElse(null);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<Object> handleTheException(final Exception ex, final Object body,
+            final HttpHeaders headers, final HttpStatus status, final WebRequest request) {
+        CH_LOGGER.error("INTERNAL ERROR", ex);
+        return super.handleExceptionInternal(ex, body, headers, status, request);
+    }
+
+    private static ApiError buildRequestBodyError(final String message, final String jsonPath,
+            final Object rejectedValue) {
+        final var error = new ApiError(message, jsonPath, LocationType.REQUEST_BODY.getValue(),
+                ErrorType.VALIDATION.getType());
+
+        Optional.ofNullable(rejectedValue)
+                .map(Object::toString)
+                .filter(Predicate.not(String::isEmpty))
+                .ifPresent(r -> error.addErrorValue("rejected", r));
+
+        return error;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandler.java
@@ -37,14 +37,13 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
             final HttpMessageNotReadableException ex, final HttpHeaders headers,
             final HttpStatus status, final WebRequest request) {
 
-        final ContentCachingRequestWrapper nativeRequest =
+        final var nativeRequest =
                 (ContentCachingRequestWrapper) ((ServletWebRequest) request).getNativeRequest();
-        final String unquotedRequestBodyAsString =
-                new String(nativeRequest.getContentAsByteArray()).replaceAll("(?:(^\")|(\"$))", "");
+        final var unquotedRequestBodyAsString =
+                new String(nativeRequest.getContentAsByteArray()).replaceAll("(^\")|(\"$)", "");
 
-        final var msg = ex.getMostSpecificCause()
-                .getMessage()
-                .replaceAll("(?s).*(line.*)", "JSON parse error: [$1");
+        final var cause = ex.getMostSpecificCause().getMessage();
+        final var msg = "JSON parse error: [" + cause.substring(cause.lastIndexOf("line:"));
         final var bodyError = buildRequestBodyError(msg, "$", unquotedRequestBodyAsString);
 
         return ResponseEntity.status(status).body(new ApiErrors(List.of(bodyError)));

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
@@ -14,6 +15,8 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -21,11 +24,13 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 import uk.gov.companieshouse.api.error.ApiError;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.officerfiling.api.exception.TransactionServiceException;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     private static final Logger CH_LOGGER = LoggerFactory.getLogger("officer-filing-api");
+    public static final String CAUSE = "cause";
 
     @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(
@@ -46,17 +51,58 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(InvalidFilingException.class)
-    public ResponseEntity<ApiErrors> handleInvalidFilingException(final InvalidFilingException ex) {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ApiErrors handleInvalidFilingException(final InvalidFilingException ex) {
         final var fieldErrors = ex.getFieldErrors();
 
         final var errorList = fieldErrors.stream()
                 .map(e -> buildRequestBodyError(e.getDefaultMessage(), getJsonPath(e),
                         e.getRejectedValue()))
                 .collect(Collectors.toList());
-        final var errors = new ApiErrors(errorList);
 
-        return ResponseEntity.badRequest().body(errors);
+        return new ApiErrors(errorList);
     }
+
+    @ExceptionHandler(TransactionServiceException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ApiErrors handleTransactionServiceException(final TransactionServiceException ex,
+            final WebRequest request) {
+        final var error = new ApiError(ex.getMessage(), getRequestURI(request),
+                LocationType.RESOURCE.getValue(), ErrorType.SERVICE.getType());
+        Optional.ofNullable(ex.getCause())
+                .ifPresent(c -> error.addErrorValue(CAUSE, c.getMessage()));
+
+        return new ApiErrors(List.of(error));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(final Exception ex, final Object body,
+            final HttpHeaders headers, final HttpStatus status, final WebRequest request) {
+        CH_LOGGER.error("INTERNAL ERROR", ex);
+        final var error = new ApiError(ex.getMessage(), getRequestURI(request),
+                LocationType.RESOURCE.getValue(), ErrorType.SERVICE.getType());
+        Optional.ofNullable(ex.getCause())
+                .ifPresent(c -> error.addErrorValue(CAUSE, c.getMessage()));
+
+        return super.handleExceptionInternal(ex, new ApiErrors(List.of(error)), headers, status,
+                request);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    public ApiErrors handleAllUncaughtException(RuntimeException ex, WebRequest request) {
+        CH_LOGGER.error("Unknown error occurred", ex);
+        final var error = new ApiError(ex.getMessage(), getRequestURI(request),
+                LocationType.RESOURCE.getValue(), ErrorType.SERVICE.getType());
+        Optional.ofNullable(ex.getCause())
+                .ifPresent(c -> error.addErrorValue(CAUSE, c.getMessage()));
+
+        return new ApiErrors(List.of(error));
+    }
+
 
     private static String getJsonPath(final FieldError e) {
         return Optional.ofNullable(e.getCodes())
@@ -68,16 +114,17 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
                 .orElse(null);
     }
 
-    @ExceptionHandler(Exception.class)
-    protected ResponseEntity<Object> handleTheException(final Exception ex, final Object body,
-            final HttpHeaders headers, final HttpStatus status, final WebRequest request) {
-        CH_LOGGER.error("INTERNAL ERROR", ex);
-        return super.handleExceptionInternal(ex, body, headers, status, request);
+    private static String getRequestURI(final WebRequest request) {
+        // resolveReference("request") preferred over getRequest() because the latter method is
+        // final and cannot be stubbed with Mockito
+        return Optional.ofNullable((HttpServletRequest) request.resolveReference("request"))
+                .map(HttpServletRequest::getRequestURI)
+                .orElse(null);
     }
 
     private static ApiError buildRequestBodyError(final String message, final String jsonPath,
             final Object rejectedValue) {
-        final var error = new ApiError(message, jsonPath, LocationType.REQUEST_BODY.getValue(),
+        final var error = new ApiError(message, jsonPath, LocationType.JSON_PATH.getValue(),
                 ErrorType.VALIDATION.getType());
 
         Optional.ofNullable(rejectedValue)

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/OfficerFilingApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/OfficerFilingApiApplicationTests.java
@@ -5,11 +5,13 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import uk.gov.companieshouse.officerfiling.api.controller.OfficerFilingController;
 
+@Tag("app")
 @SpringBootTest
 class OfficerFilingApiApplicationTests {
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/OfficerFilingApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/OfficerFilingApiApplicationTests.java
@@ -11,9 +11,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class OfficerFilingApiApplicationTests {
 
-	@Test
-	void contextLoads() {
+    @Test
+    void contextLoads() {
         assertThat("TODO", is(not(emptyString())));
-	}
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandlerTest.java
@@ -1,0 +1,167 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.FieldError;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import uk.gov.companieshouse.api.error.ApiError;
+import uk.gov.companieshouse.officerfiling.api.exception.TransactionServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class RestExceptionHandlerTest {
+    public static final String MALFORMED_JSON_QUOTED = "\"{\"";
+    private RestExceptionHandler testExceptionHandler;
+
+    @Mock
+    private HttpHeaders headers;
+    @Mock
+    private ServletWebRequest request;
+    @Mock
+    private ContentCachingRequestWrapper requestWrapper;
+
+    private MockHttpServletRequest servletRequest;
+
+    @BeforeEach
+    void setUp() {
+        testExceptionHandler = new RestExceptionHandler();
+        servletRequest = new MockHttpServletRequest();
+        servletRequest.setRequestURI("/path/to/resource");
+    }
+
+    @Test
+    void handleHttpMessageNotReadableWithRedactedMessage() {
+        final var message = new MockHttpInputMessage(MALFORMED_JSON_QUOTED.getBytes());
+        final var exceptionWithNamedClass = new HttpMessageNotReadableException(
+                "Unexpected end-of-input: "
+                        + "expected close marker for Object (start marker at [Source: (org"
+                        + ".springframework.util.StreamUtils$NonClosingInputStream); line: 1, "
+                        + "column: 1])"
+                        + "\\n at [Source: (org.springframework.util"
+                        + ".StreamUtils$NonClosingInputStream); "
+                        + "line: 1, column: 2]", message);
+
+        when(request.getNativeRequest()).thenReturn(requestWrapper);
+        when(requestWrapper.getContentAsByteArray()).thenReturn(MALFORMED_JSON_QUOTED.getBytes());
+
+        final var response =
+                testExceptionHandler.handleHttpMessageNotReadable(exceptionWithNamedClass, headers,
+                        HttpStatus.BAD_REQUEST, request);
+        final var apiErrors = (ApiErrors) response.getBody();
+        final var expectedError = new ApiError("test", "$", "json-path", "ch:validation");
+        final var actualError = apiErrors.getErrors().iterator().next();
+
+        expectedError.addErrorValue("body", MALFORMED_JSON_QUOTED);
+        assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+        assertThat(apiErrors.getErrors(), hasSize(1));
+        assertThat(actualError, is(samePropertyValuesAs(expectedError, "error")));
+        assertThat(actualError.getError(), not(containsString(
+                "Source: (org.springframework.util.StreamUtils$NonClosingInputStream);")));
+    }
+
+    @Test
+    void handleInvalidFilingException() {
+        final var fieldError = new FieldError("object", "field", "error");
+        final String[] codes = {"code1", "code2.name", "code3"};
+        final var fieldErrorWithRejectedValue =
+                new FieldError("object", "field", "rejectedValue", false, codes, null,
+                        "errorWithRejectedValue");
+        final var exception =
+                new InvalidFilingException(List.of(fieldError, fieldErrorWithRejectedValue));
+
+        final var apiErrors = testExceptionHandler.handleInvalidFilingException(exception);
+
+        final var expectedError = new ApiError("error", null, "json-path", "ch:validation");
+        final var expectedErrorWithRejectedValue =
+                new ApiError("errorWithRejectedValue", "$.name", "json-path", "ch:validation");
+
+        expectedErrorWithRejectedValue.addErrorValue("rejected", "rejectedValue");
+
+        assertThat(apiErrors.getErrors(), contains(expectedError, expectedErrorWithRejectedValue));
+    }
+
+    @ParameterizedTest(name = "[{index}]: cause={0}")
+    @NullSource
+    @MethodSource("causeProvider")
+    void handleTransactionServiceException(final Exception cause) {
+        final var exception = new TransactionServiceException("test", cause);
+
+        when(request.resolveReference("request")).thenReturn(servletRequest);
+
+        final var apiErrors =
+                testExceptionHandler.handleTransactionServiceException(exception, request);
+
+        final var expectedError =
+                new ApiError("test", "/path/to/resource", "resource", "ch:service");
+
+        if (cause != null) {
+            expectedError.addErrorValue("cause", cause.getMessage());
+        }
+        assertThat(apiErrors.getErrors(), contains(expectedError));
+    }
+
+    @Test
+    void handleExceptionInternal() {
+        final var exception = new NullPointerException("test");
+        final Object body = Integer.valueOf(0);
+
+        when(request.resolveReference("request")).thenReturn(servletRequest);
+
+        final var response =
+                testExceptionHandler.handleExceptionInternal(exception, body, new HttpHeaders(),
+                        HttpStatus.INTERNAL_SERVER_ERROR, request);
+
+        final var apiErrors = (ApiErrors) response.getBody();
+        final var expectedError =
+                new ApiError("test", "/path/to/resource", "resource", "ch:service");
+
+        assertThat(apiErrors.getErrors(), contains(expectedError));
+    }
+
+    @ParameterizedTest(name = "[{index}]: cause={0}")
+    @NullSource
+    @MethodSource("causeProvider")
+    void handleAllUncaughtException(final Exception cause) {
+        final var exception = new RuntimeException("test", cause);
+
+        when(request.resolveReference("request")).thenReturn(servletRequest);
+
+        final var apiErrors = testExceptionHandler.handleAllUncaughtException(exception, request);
+
+        final var expectedError =
+                new ApiError("test", "/path/to/resource", "resource", "ch:service");
+
+        if (cause != null) {
+            expectedError.addErrorValue("cause", cause.getMessage());
+        }
+        assertThat(apiErrors.getErrors(), contains(expectedError));
+    }
+
+    private static Stream<Arguments> causeProvider() {
+        return Stream.of(Arguments.of(new ArithmeticException("DIV/0")));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandlerTest.java
@@ -85,7 +85,7 @@ class RestExceptionHandlerTest {
     @Test
     void handleInvalidFilingException() {
         final var fieldError = new FieldError("object", "field", "error");
-        final String[] codes = {"code1", "code2.name", "code3"};
+        final var codes = new String[]{"code1", "code2.name", "code3"};
         final var fieldErrorWithRejectedValue =
                 new FieldError("object", "field", "rejectedValue", false, codes, null,
                         "errorWithRejectedValue");


### PR DESCRIPTION
- add RestExceptionHandler and support types
- add handling for error types when they occur:
  - JSON not readable
  - data validation errors (TBD)
  - Transaction service failures
  - internal server error
  - other errors (catch-all)
- increase unit and integration test coverage

Resolves:
DACT-129