### PR TITLE
Add outline of validation controller

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -4,3 +4,4 @@ weight: 900
 routes:
   1: ^/officers
   2: ^/transactions/.*/officers
+  3: ^/private/transactions/.*/officers

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
@@ -110,7 +110,9 @@ public class OfficerFilingControllerImpl implements OfficerFilingController {
         final var uriBuilder = UriComponentsBuilder.fromUriString(request.getRequestURI())
                 .pathSegment(objectId.toHexString());
         final var selfUri = uriBuilder.build().toUri();
-        final var validateUri = uriBuilder.pathSegment(VALIDATION_STATUS)
+        final var privateUriBuilder = UriComponentsBuilder.fromUriString("private/" + request.getRequestURI())
+                .pathSegment(objectId.toHexString());
+        final var validateUri = privateUriBuilder.pathSegment(VALIDATION_STATUS)
                 .build().toUri();
 
         return new Links(selfUri, validateUri);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
+import static uk.gov.companieshouse.officerfiling.api.model.entity.Links.PREFIX_PRIVATE;
+
 import java.time.Clock;
 import java.time.ZoneId;
 import java.util.HashMap;
@@ -110,7 +112,7 @@ public class OfficerFilingControllerImpl implements OfficerFilingController {
         final var uriBuilder = UriComponentsBuilder.fromUriString(request.getRequestURI())
                 .pathSegment(objectId.toHexString());
         final var selfUri = uriBuilder.build().toUri();
-        final var privateUriBuilder = UriComponentsBuilder.fromUriString("private/" + request.getRequestURI())
+        final var privateUriBuilder = UriComponentsBuilder.fromUriString(PREFIX_PRIVATE + "/" + request.getRequestURI())
                 .pathSegment(objectId.toHexString());
         final var validateUri = privateUriBuilder.pathSegment(VALIDATION_STATUS)
                 .build().toUri();

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+public interface ValidationStatusController {
+    @GetMapping(value = "/{filingResourceId}/validation_status", produces = {"application/json"})
+    ResponseEntity validate(@PathVariable("transId") String transId,
+                            @PathVariable("filingResourceId") String filingResource);
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
@@ -1,15 +1,16 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
+import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
 
 public interface ValidationStatusController {
     @GetMapping(value = "/{filingResourceId}/validation_status", produces = {"application/json"})
-    default ResponseEntity validate(@PathVariable("transId") String transId,
-                                    @PathVariable("filingResourceId") String filingResource) {
-        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    default ValidationStatusResponse validate(@PathVariable("transId") String transId,
+                                              @PathVariable("filingResourceId") String filingResource) {
+
+        throw new NotImplementedException();
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
@@ -1,11 +1,15 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 public interface ValidationStatusController {
     @GetMapping(value = "/{filingResourceId}/validation_status", produces = {"application/json"})
-    ResponseEntity validate(@PathVariable("transId") String transId,
-                            @PathVariable("filingResourceId") String filingResource);
+    default ResponseEntity validate(@PathVariable("transId") String transId,
+                                    @PathVariable("filingResourceId") String filingResource) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
@@ -8,10 +8,19 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
+import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
 
 @RestController
 @RequestMapping("/private/transactions/{transId}/officers")
 public class ValidationStatusControllerImpl implements ValidationStatusController {
+    private final OfficerFilingService officerFilingService;
+
+    public ValidationStatusControllerImpl(OfficerFilingService officerFilingService) {
+        this.officerFilingService = officerFilingService;
+    }
+
     @Override
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
@@ -19,6 +28,12 @@ public class ValidationStatusControllerImpl implements ValidationStatusControlle
     public ValidationStatusResponse validate(@PathVariable("transId") final String transId,
                                      @PathVariable("filingResourceId") final String filingResource) {
 
+        var maybeOfficerFiling = officerFilingService.get(filingResource);
+
+        return maybeOfficerFiling.map(this::isValid).orElseThrow(ResourceNotFoundException::new);
+    }
+
+    private ValidationStatusResponse isValid(OfficerFiling officerFiling) {
         var validationStatus = new ValidationStatusResponse();
         validationStatus.setValid(true);
         return validationStatus;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
@@ -1,19 +1,26 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 
 @RestController
 @RequestMapping("/private/transactions/{transId}/officers")
 public class ValidationStatusControllerImpl implements ValidationStatusController {
     @Override
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping(value = "/{filingResourceId}/validation_status", produces = {"application/json"})
-    public ResponseEntity validate(@PathVariable("transId") final String transId,
-                                   @PathVariable("filingResourceId") final String filingResource) {
+    public ValidationStatusResponse validate(@PathVariable("transId") final String transId,
+                                     @PathVariable("filingResourceId") final String filingResource) {
 
-        return ResponseEntity.ok().build();
+        var validationStatus = new ValidationStatusResponse();
+        validationStatus.setValid(true);
+        return validationStatus;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/private/transactions/{transId}/officers")
+public class ValidationStatusControllerImpl implements ValidationStatusController {
+    @Override
+    @GetMapping(value = "/{filingResourceId}/validation_status", produces = {"application/json"})
+    public ResponseEntity validate(@PathVariable("transId") final String transId,
+                                   @PathVariable("filingResourceId") final String filingResource) {
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/NotImplementedException.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/NotImplementedException.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.officerfiling.api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_IMPLEMENTED)
+public class NotImplementedException extends RuntimeException {
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/ResourceNotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.officerfiling.api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/Links.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/Links.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 public class Links {
+    public static final String PREFIX_PRIVATE = "/private";
     private final URI self;
     private final URI validationStatus;
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/TransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/TransactionServiceImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.officerfiling.api.service;
 
+import static uk.gov.companieshouse.officerfiling.api.model.entity.Links.PREFIX_PRIVATE;
+
 import java.io.IOException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
@@ -36,7 +38,7 @@ public class TransactionServiceImpl implements TransactionService {
     public void updateTransaction(final Transaction transaction, final String ericPassThroughHeader)
             throws TransactionServiceException {
         try {
-            final var uri = "/private/transactions/" + transaction.getId();
+            final var uri = PREFIX_PRIVATE + "/transactions/" + transaction.getId();
             final var resp = apiClientService.getInternalOauthAuthenticatedClient(ericPassThroughHeader)
                     .privateTransaction()
                     .patch(uri, transaction)

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.officerfiling.api.controller.OfficerFilingControllerImpl.VALIDATION_STATUS;
+import static uk.gov.companieshouse.officerfiling.api.model.entity.Links.PREFIX_PRIVATE;
 
 import java.net.URI;
 import java.time.Clock;
@@ -83,8 +84,9 @@ class OfficerFilingControllerImplTest {
                 .resignedOn(Instant.parse("2022-09-13T00:00:00Z"))
                 .build();
         final var builder = UriComponentsBuilder.fromUri(REQUEST_URI);
+        final var privateBuilder = UriComponentsBuilder.fromUri(URI.create(PREFIX_PRIVATE + "/" + REQUEST_URI));
         links = new Links(builder.pathSegment(FILING_ID)
-                .build().toUri(), builder.pathSegment("validation_status")
+                .build().toUri(), privateBuilder.pathSegment(FILING_ID).pathSegment("validation_status")
                 .build().toUri());
         resourceMap = createResources();
     }
@@ -139,7 +141,7 @@ class OfficerFilingControllerImplTest {
         final var resource = new Resource();
         final var self = REQUEST_URI + "/" + FILING_ID;
         final var linksMap = Map.of("resource", self, VALIDATION_STATUS,
-                REQUEST_URI + "/" + FILING_ID + "/" + VALIDATION_STATUS);
+                PREFIX_PRIVATE + "/" + REQUEST_URI + "/" + FILING_ID + "/" + VALIDATION_STATUS);
 
         resource.setKind("officer-filing");
         resource.setLinks(linksMap);

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
@@ -1,0 +1,65 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
+
+@Tag("web")
+@WebMvcTest(controllers = ValidationStatusControllerImpl.class)
+class ValidationStatusControllerImplIT {
+    private static final String TRANS_ID = "4f56fdf78b357bfc";
+    private static final String FILING_ID = "632c8e65105b1b4a9f0d1f5e";
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+
+    @MockBean
+    private OfficerFilingService officerFilingService;
+
+    private HttpHeaders httpHeaders;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        httpHeaders = new HttpHeaders();
+        httpHeaders.add("ERIC-Access-Token", PASSTHROUGH_HEADER);
+    }
+
+    @Test
+    void validationStatusWhenFound() throws Exception {
+        final var filing = OfficerFiling.builder().build();
+        when(officerFilingService.get(FILING_ID)).thenReturn(Optional.of(filing));
+
+        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID)
+            .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.is_valid", is(true)));
+    }
+
+    @Test
+    void validationStatusWhenNotFound() throws Exception {
+        when(officerFilingService.get(FILING_ID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID)
+                        .headers(httpHeaders))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$").doesNotExist());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
@@ -2,25 +2,47 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
 
+@ExtendWith(MockitoExtension.class)
 class ValidationStatusControllerImplTest {
 
     public static final String TRANS_ID = "117524-754816-491724";
     public static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
+    @Mock
+    private OfficerFilingService officerFilingService;
+
     private ValidationStatusControllerImpl testController;
 
     @BeforeEach
     void setUp() {
-        testController = new ValidationStatusControllerImpl();
+        testController = new ValidationStatusControllerImpl(officerFilingService);
     }
 
     @Test
-    void validate() {
+    void validateWhenFound() {
+        var filing = OfficerFiling.builder().build();
+        when(officerFilingService.get(FILING_ID)).thenReturn(Optional.of(filing));
         final var response= testController.validate(TRANS_ID, FILING_ID);
 
         assertThat(response.isValid(), is(true));
+    }
+
+    @Test
+    void validateWhenNotFound() {
+        when(officerFilingService.get(FILING_ID)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> testController.validate(TRANS_ID, FILING_ID));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class ValidationStatusControllerImplTest {
+
+    public static final String TRANS_ID = "117524-754816-491724";
+    public static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
+    private ValidationStatusControllerImpl testController;
+
+    @BeforeEach
+    void setUp() {
+        testController = new ValidationStatusControllerImpl();
+    }
+
+    @Test
+    void validate() {
+        final var response= testController.validate(TRANS_ID, FILING_ID);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
 class ValidationStatusControllerImplTest {
 
@@ -22,6 +21,6 @@ class ValidationStatusControllerImplTest {
     void validate() {
         final var response= testController.validate(TRANS_ID, FILING_ID);
 
-        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.isValid(), is(true));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerTest.java
@@ -1,18 +1,16 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
+import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
 
 class ValidationStatusControllerTest {
 
     @Test
     void validate() {
-        final var response = new ValidationStatusController() {
-        }.validate("trans-id", "filing-id");
+        assertThrows(NotImplementedException.class, () -> new ValidationStatusController() {
+        }.validate("trans-id", "filing-id"));
 
-        assertThat(response.getStatusCode(), is(HttpStatus.NOT_IMPLEMENTED));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerTest.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class ValidationStatusControllerTest {
+
+    @Test
+    void validate() {
+        final var response = new ValidationStatusController() {
+        }.validate("trans-id", "filing-id");
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_IMPLEMENTED));
+    }
+}


### PR DESCRIPTION
This is the bare bones of a `validation_status` endpoint.  The actual validation to be added in later story.  This is part of allowing the transaction to proceed to CHIPS.

Response:
```
{
    "is_valid": true
}
```

DACT-127

needs docker-chs-dev change here: https://github.com/companieshouse/docker-chs-development/pull/538