### PR TITLE
Add/improve unit test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <!-- Docker -->
         <jib-maven-plugin.version>3.2.1</jib-maven-plugin.version>
-        <mockito-core.version>4.7.0</mockito-core.version>
-        <equalsverifier.version>3.7.2</equalsverifier.version>
+        <mockito-core.version>4.8.0</mockito-core.version>
+        <equalsverifier.version>3.10.1</equalsverifier.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <!--- CH -->
         <structured-logging.version>1.9.14</structured-logging.version>
@@ -113,7 +113,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/error/ApiErrorsTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/error/ApiErrorsTest.java
@@ -1,0 +1,108 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.error.ApiError;
+
+class ApiErrorsTest {
+    private ApiErrors testErrors;
+
+    @BeforeEach
+    void setUp() {
+        testErrors = new ApiErrors();
+    }
+
+    @Test
+    void noArgConstructor() {
+        assertThat(testErrors.getErrors(), is(Collections.emptySet()));
+    }
+
+    @Test
+    @DisplayName("Constructor: ignore duplicate elements")
+    void collectionConstructor() {
+        final var error = new ApiError();
+
+        final var uniqueErrors = new ApiErrors(Collections.nCopies(3, error));
+
+        assertThat(uniqueErrors.getErrors(), contains(error));
+    }
+
+
+    @Test
+    @DisplayName("add(): unique elements only")
+    void add() {
+        final var error = new ApiError();
+
+        testErrors.add(error);
+        testErrors.add(error);
+
+        assertThat(testErrors.getErrors(), contains(error));
+    }
+
+    @Test
+    @DisplayName("add(): null arg not allowed")
+    void addWhenNull() {
+        assertThrows(NullPointerException.class, () -> testErrors.add(null));
+    }
+
+    @Test
+    void hasErrors() {
+        final var error = new ApiError();
+
+        assertThat(testErrors.hasErrors(), is(false));
+
+        testErrors.add(error);
+
+        assertThat(testErrors.hasErrors(), is(true));
+    }
+
+    @Test
+    void containsError() {
+        final var error = new ApiError();
+
+        assertThat(testErrors.contains(error), is(false));
+
+        testErrors.add(error);
+
+        assertThat(testErrors.contains(error), is(true));
+    }
+
+    @Test
+    @DisplayName("contains(): null arg not allowed")
+    void containsNull() {
+        assertThrows(NullPointerException.class, () -> testErrors.contains(null));
+    }
+
+    @Test
+    @DisplayName("getErrors(): unique elements")
+    void getErrors() {
+        final var error = new ApiError();
+
+        assertThat(testErrors.getErrors(), is(Collections.emptySet()));
+
+        testErrors.add(error);
+        testErrors.add(error);
+
+        assertThat(testErrors.getErrors(), contains(error));
+    }
+
+    @Test
+    @DisplayName("getErrorCount(): unique elements")
+    void getErrorCount() {
+        final var error = new ApiError();
+
+        assertThat(testErrors.getErrorCount(), is(0));
+
+        testErrors.add(error);
+        testErrors.add(error);
+
+        assertThat(testErrors.getErrorCount(), is(1));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/error/CachingFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/error/CachingFilterTest.java
@@ -1,0 +1,61 @@
+package uk.gov.companieshouse.officerfiling.api.error;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@ExtendWith(MockitoExtension.class)
+class CachingFilterTest {
+    private CachingFilter testFilter;
+
+    @Mock
+    private ServletResponse servletResponse;
+    @Mock
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        testFilter = new CachingFilter();
+    }
+
+    @Test
+    @DisplayName("doFilter(): verify chained call uses correct type")
+        // without mockito-inline: only able to verify ContentCachingRequestWrapper type is used
+        // in chained call
+    void doFilterNonInline() throws ServletException, IOException {
+        final var servletRequest = new MockHttpServletRequest();
+
+        testFilter.doFilter(servletRequest, servletResponse, filterChain);
+
+        verify(filterChain).doFilter(isA(ContentCachingRequestWrapper.class), eq(servletResponse));
+    }
+
+    @Test
+    @DisplayName("doFilter(): verify chained call uses correct instance")
+        // with mockito-inline: able to verify constructed ContentCachingRequestWrapper instance
+        // is used in chained call
+    void doFilter() throws ServletException, IOException {
+        final var servletRequest = new MockHttpServletRequest();
+
+        try (final var requestWrapper = mockConstruction(ContentCachingRequestWrapper.class)) {
+            testFilter.doFilter(servletRequest, servletResponse, filterChain);
+
+            verify(filterChain).doFilter(requestWrapper.constructed().get(0), servletResponse);
+        }
+
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/ApiClientServiceImplTest.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.officerfiling.api.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+@ExtendWith(MockitoExtension.class)
+class ApiClientServiceImplTest {
+    public static final String PASSTHROUGH_HEADER = "passthrough";
+    private ApiClientService testService;
+
+    @Mock
+    private ApiClient apiClient;
+    @Mock
+    private InternalApiClient internalApiClient;
+
+    @BeforeEach
+    void setUp() {
+        testService = new ApiClientServiceImpl();
+    }
+
+    @Test
+    void getApiKeyAuthenticatedClient() {
+        try (final var sdkManager = mockStatic(ApiSdkManager.class)) {
+            sdkManager.when(ApiSdkManager::getSDK).thenReturn(apiClient);
+
+            final var client = testService.getApiKeyAuthenticatedClient();
+
+            assertThat(client, is(apiClient));
+        }
+    }
+
+    @Test
+    void getOauthAuthenticatedClient() throws IOException {
+        try (final var sdkManager = mockStatic(ApiSdkManager.class)) {
+            sdkManager.when(() -> ApiSdkManager.getSDK(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+
+            final var client = testService.getOauthAuthenticatedClient(PASSTHROUGH_HEADER);
+
+            assertThat(client, is(apiClient));
+        }
+    }
+
+    @Test
+    void getInternalOauthAuthenticatedClient() throws IOException {
+        try (final var sdkManager = mockStatic(ApiSdkManager.class)) {
+            sdkManager.when(() -> ApiSdkManager.getPrivateSDK(PASSTHROUGH_HEADER)).thenReturn(internalApiClient);
+
+            final var client = testService.getInternalOauthAuthenticatedClient(PASSTHROUGH_HEADER);
+
+            assertThat(client, is(internalApiClient));
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerFilingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerFilingServiceImplTest.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.officerfiling.api.service;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
+import uk.gov.companieshouse.officerfiling.api.repository.OfficerFilingRepository;
+
+@ExtendWith(MockitoExtension.class)
+class OfficerFilingServiceImplTest {
+    private OfficerFilingService testService;
+
+    @Mock
+    private OfficerFilingRepository repository;
+    @Mock
+    private OfficerFiling filing;
+
+    @BeforeEach
+    void setUp() {
+        testService = new OfficerFilingServiceImpl(repository);
+    }
+
+    @Test
+    void save() {
+        testService.save(filing);
+
+        verify(repository).save(filing);
+    }
+}


### PR DESCRIPTION
- improve test quality on static/constructor code

POM:
- replace mockito-core with mockito-inline
  - enable static and constructor mocking
- bump mockito to 4.8.0
- bump equalsverifier to 3.10.1
