### PR TITLE
DACT-249 Validate that company has not been dissolved

### DIFF
--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileServiceImplTest.java
@@ -53,7 +53,7 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void companyAppointmentIsReturnedFromCompanyAppointmentsAPIWhenFound() throws IOException, URIValidationException {
+    void companyProfileIsReturnedFromAPIWhenFound() throws IOException, URIValidationException {
         when(apiResponse.getData()).thenReturn(mockCompanyProfileApi);
         when(companyGet.execute()).thenReturn(apiResponse);
         when(companyResourceHandler.get(URI)).thenReturn(companyGet);
@@ -66,7 +66,7 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void exceptionIsThrownWhenCompanyAppointmentIsNotFound() throws IOException, URIValidationException {
+    void exceptionIsThrownWhenCompanyProfileIsNotFound() throws IOException, URIValidationException {
         when(companyGet.execute()).thenThrow(URIValidationException.class);
         when(companyResourceHandler.get(URI)).thenReturn(companyGet);
         when(internalApiClient.company()).thenReturn(companyResourceHandler);

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -185,4 +185,35 @@ class OfficerTerminationValidatorTest {
                 .as("An error should not be produced when resignation date is the creation date")
                 .isEmpty();
     }
+
+    @Test
+    void validateCompanyNotDissolvedWhenDissolvedDateExists() {
+        when(companyProfile.getDateOfCessation()).thenReturn(LocalDate.of(2023, Month.JANUARY, 4));
+        officerTerminationValidator.validateCompanyNotDissolved(request, apiErrorsList, companyProfile);
+        assertThat(apiErrorsList)
+                .as("An error should be produced when dissolved date exists")
+                .hasSize(1)
+                .extracting(ApiError::getError)
+                .contains("You cannot remove a director from a company that's been dissolved");
+    }
+
+    @Test
+    void validateCompanyNotDissolvedWhenStatusIsDissolved() {
+        when(companyProfile.getCompanyStatus()).thenReturn("dissolved");
+        officerTerminationValidator.validateCompanyNotDissolved(request, apiErrorsList, companyProfile);
+        assertThat(apiErrorsList)
+                .as("An error should be produced when the company has a status of 'dissolved'")
+                .hasSize(1)
+                .extracting(ApiError::getError)
+                .contains("You cannot remove a director from a company that's been dissolved or is about to be dissolved");
+    }
+
+    @Test
+    void validateCompanyNotDissolvedWhenValid() {
+        when(companyProfile.getCompanyStatus()).thenReturn("active");
+        officerTerminationValidator.validateCompanyNotDissolved(request, apiErrorsList, companyProfile);
+        assertThat(apiErrorsList)
+                .as("An error should not be produced when the company is active")
+                .isEmpty();
+    }
 }


### PR DESCRIPTION
Validate that company has not been dissolved or in the process of being dissolved

- **As** Companies House

- **I want** users to be prevented from filing for the removal of a director who has already had a removal filed against them which has not yet been completed 

- **So that** the original termination date is the one that is persisted and the system does not get in a state