### PR TITLE
DACT-249: Validation error fix for dissolved company

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
@@ -113,11 +113,11 @@ public class OfficerTerminationValidator {
     }
 
     public void validateCompanyNotDissolved(HttpServletRequest request, List<ApiError> errorList, CompanyProfileApi companyProfile) {
-        if (companyProfile.getDateOfCessation() != null){
-            createValidationError(request, errorList, "You cannot remove a director from a company that's been dissolved");
-        }
         if (Objects.equals(companyProfile.getCompanyStatus(), "dissolved")) {
-            createValidationError(request, errorList, "You cannot remove a director from a company that's been dissolved or is about to be dissolved");
+            createValidationError(request, errorList, "You cannot remove an officer from a company that has been dissolved");
+        }
+        else if (companyProfile.getDateOfCessation() != null){
+            createValidationError(request, errorList, "You cannot remove an officer from a company that is about to be dissolved");
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -223,7 +223,7 @@ class OfficerTerminationValidatorTest {
                 .as("An error should be produced when dissolved date exists")
                 .hasSize(1)
                 .extracting(ApiError::getError)
-                .contains("You cannot remove a director from a company that's been dissolved");
+                .contains("You cannot remove an officer from a company that is about to be dissolved");
     }
 
     @Test
@@ -234,7 +234,7 @@ class OfficerTerminationValidatorTest {
                 .as("An error should be produced when the company has a status of 'dissolved'")
                 .hasSize(1)
                 .extracting(ApiError::getError)
-                .contains("You cannot remove a director from a company that's been dissolved or is about to be dissolved");
+                .contains("You cannot remove an officer from a company that has been dissolved");
     }
 
     @Test


### PR DESCRIPTION
Error message fix for companies with cessation date and/or dissolved status: only one of these errors should be returned. If a company has both a cessation date and a dissolved status, only the error case for a dissolved company should be shown.