### PR TITLE
Dact 145 add token permission interceptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <structured-logging.version>1.9.14</structured-logging.version>
         <private-api-sdk-java.version>2.0.207</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
+        <api-security-java.version>unversioned</api-security-java.version>
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml,
             ${project.build.directory}/site/jacoco-it/jacoco.xml
@@ -77,6 +78,11 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-security-java</artifactId>
+            <version>${api-security-java.version}</version>
         </dependency>
         <!-- SDKs -->
         <dependency>

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/OfficerFilingApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/OfficerFilingApiApplication.java
@@ -6,6 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class OfficerFilingApiApplication {
 
+    public static final String APP_NAMESPACE = "officer-filing-api";
+
     public static void main(final String[] args) {
         SpringApplication.run(OfficerFilingApiApplication.class, args);
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/config/InterceptorConfig.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.officerfiling.api.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.officerfiling.api.interceptor.TokenPermissionInterceptor;
+
+@Configuration
+@ComponentScan("uk.gov.companieshouse.officerfiling.api.interceptor")
+public class InterceptorConfig implements WebMvcConfigurer {
+
+    static final String OFFICERS_ENDPOINT = "/transactions/{transId}/officers";
+    static final String OFFICERS_FILING_ENDPOINT = "/transactions/{transId}/officers/{filingResourceId}";
+
+    static final String PRIVATE_OFFICERS_FILING_ENDPOINT = "/private/transactions/{transId}/officers/{filingResourceId}/filings";
+
+
+    /**
+     * Setup the interceptors to run against endpoints when the endpoints are called
+     * Interceptors are executed in the order they are added to the registry
+     * @param registry The spring interceptor registry
+     */
+    @Override
+    public void addInterceptors(@NonNull InterceptorRegistry registry) {
+        TokenPermissionInterceptor tokenPermissionInterceptor = new TokenPermissionInterceptor();
+        registry.addInterceptor(tokenPermissionInterceptor).addPathPatterns(OFFICERS_FILING_ENDPOINT, OFFICERS_ENDPOINT, PRIVATE_OFFICERS_FILING_ENDPOINT);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
@@ -50,8 +50,12 @@ public class OfficerFilingControllerImpl implements OfficerFilingController {
     private final Logger logger;
 
     public OfficerFilingControllerImpl(final TransactionService transactionService,
-            final OfficerFilingService officerFilingService, final CompanyProfileService companyProfileService, final CompanyAppointmentService companyAppointmentService, final OfficerFilingMapper filingMapper,
-            final Clock clock, final Logger logger) {
+                                       final OfficerFilingService officerFilingService,
+                                       final CompanyProfileService companyProfileService,
+                                       final CompanyAppointmentService companyAppointmentService,
+                                       final OfficerFilingMapper filingMapper,
+                                       final Clock clock,
+                                       final Logger logger) {
         this.transactionService = transactionService;
         this.officerFilingService = officerFilingService;
         this.companyProfileService = companyProfileService;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/interceptor/TokenPermissionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/interceptor/TokenPermissionInterceptor.java
@@ -1,0 +1,95 @@
+package uk.gov.companieshouse.officerfiling.api.interceptor;
+
+import static uk.gov.companieshouse.officerfiling.api.utils.Constants.ERIC_REQUEST_ID_KEY;
+import static uk.gov.companieshouse.officerfiling.api.utils.Constants.TRANSACTION_ID_KEY;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.officerfiling.api.OfficerFilingApiApplication;
+
+
+@Component
+public class TokenPermissionInterceptor implements HandlerInterceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(OfficerFilingApiApplication.APP_NAMESPACE);
+    /**
+     * Pre handle method to authorize the request before it reaches the controller. Retrieves the
+     * TokenPermissions stored in the request (which must have been previously added by the
+     * TokenPermissionsInterceptor) and checks the relevant permissions
+     */
+    @Override
+    public boolean preHandle(@NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response, @NonNull Object handler) {
+        final Map<String, String> pathVariables =
+                (Map<String, String>) request.getAttribute(
+                        HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        final var transactionId = pathVariables.get(TRANSACTION_ID_KEY);
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put(TRANSACTION_ID_KEY, transactionId);
+        String reqId = request.getHeader(ERIC_REQUEST_ID_KEY);
+
+        // skip token permission checks if an api key is used, api key elevated privileges are checked in other interceptors
+        // inside company accounts and abridged accounts api services
+/*        if (SecurityConstants.API_KEY_IDENTITY_TYPE.equals(
+                AuthorisationUtil.getAuthorisedIdentityType(request))) {
+            logger.debugContext(reqId,
+                    "TokenPermissionInterceptor skipping token permission checks for api key request",
+                    logMap);
+            return true;
+        }*/
+
+        // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
+        final var tokenPermissions = getTokenPermissions(request)
+                .orElseThrow(() -> new IllegalStateException(
+                        "TokenPermissionInterceptor - TokenPermissions object not present in request"));
+
+        // Check the user has the company_officers=delete permission
+        boolean hasCompanyOfficersDeletePermission = tokenPermissions.hasPermission(
+                Key.COMPANY_OFFICERS, Value.DELETE);
+
+        // Check the user has the company_officers=readprotected permission
+        boolean hasCompanyOfficersReadProtectedPermission = tokenPermissions.hasPermission(
+                Key.COMPANY_OFFICERS, Value.READ_PROTECTED);
+
+        var authInfoMap = new HashMap<String, Object>();
+        authInfoMap.put(TRANSACTION_ID_KEY, transactionId);
+        authInfoMap.put("request_method", request.getMethod());
+        authInfoMap.put("has_company_officers_delete_permission",
+                hasCompanyOfficersDeletePermission);
+        authInfoMap.put("has_company_officers_readprotected_permission",
+                hasCompanyOfficersReadProtectedPermission);
+
+        if (hasCompanyOfficersDeletePermission && hasCompanyOfficersReadProtectedPermission) {
+            logger.debugContext(reqId,
+                    "TokenPermissionInterceptor authorised with company_officers=readprotected and company_officers=delete permissions",
+                    authInfoMap);
+            return true;
+        }
+
+        logger.errorContext(reqId, "TokenPermissionInterceptor unauthorised", null,
+                authInfoMap);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        return false;
+    }
+
+    protected Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
+        return AuthorisationUtil.getTokenPermissions(request);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/interceptor/TokenPermissionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/interceptor/TokenPermissionInterceptor.java
@@ -45,16 +45,6 @@ public class TokenPermissionInterceptor implements HandlerInterceptor {
         logMap.put(TRANSACTION_ID_KEY, transactionId);
         String reqId = request.getHeader(ERIC_REQUEST_ID_KEY);
 
-        // skip token permission checks if an api key is used, api key elevated privileges are checked in other interceptors
-        // inside company accounts and abridged accounts api services
-/*        if (SecurityConstants.API_KEY_IDENTITY_TYPE.equals(
-                AuthorisationUtil.getAuthorisedIdentityType(request))) {
-            logger.debugContext(reqId,
-                    "TokenPermissionInterceptor skipping token permission checks for api key request",
-                    logMap);
-            return true;
-        }*/
-
         // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
         final var tokenPermissions = getTokenPermissions(request)
                 .orElseThrow(() -> new IllegalStateException(

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/OfficerFilingDto.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/OfficerFilingDto.java
@@ -14,8 +14,6 @@ import java.util.stream.Stream;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PastOrPresent;
-
-import org.springframework.data.annotation.Id;
 import org.springframework.validation.annotation.Validated;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
 
@@ -23,8 +21,6 @@ import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
 @Validated
 public class OfficerFilingDto {
 
-    @Id
-    private String id;
     private AddressDto address;
     private Boolean addressSameAsRegisteredOfficeAddress;
     private LocalDate appointedOn;
@@ -47,10 +43,6 @@ public class OfficerFilingDto {
     private Boolean residentialAddressSameAsCorrespondenceAddress;
 
     private OfficerFilingDto() {
-    }
-
-    public String getId() {
-        return id;
     }
 
     public AddressDto getAddress() {
@@ -126,8 +118,7 @@ public class OfficerFilingDto {
             return false;
         }
         final var that = (OfficerFilingDto) o;
-        return Objects.equals(getId(), that.getId())
-                && Objects.equals(getAddress(), that.getAddress())
+        return Objects.equals(getAddress(), that.getAddress())
                 && Objects.equals(getAddressSameAsRegisteredOfficeAddress(),
                 that.getAddressSameAsRegisteredOfficeAddress())
                 && Objects.equals(getAppointedOn(), that.getAppointedOn())
@@ -149,7 +140,7 @@ public class OfficerFilingDto {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getAddress(), getAddressSameAsRegisteredOfficeAddress(),
+        return Objects.hash(getAddress(), getAddressSameAsRegisteredOfficeAddress(),
                 getAppointedOn(), getCountryOfResidence(), getDateOfBirth(), getFormerNames(),
                 getIdentification(), getName(), getNationality(), getOccupation(),
                 getReferenceEtag(), getReferenceAppointmentId(), getReferenceOfficerListEtag(),
@@ -159,9 +150,8 @@ public class OfficerFilingDto {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", OfficerFiling.class.getSimpleName() + "[", "]").add(
-                        "id='" + id + "'")
-                .add("address=" + address)
+        return new StringJoiner(", ", OfficerFilingDto.class.getSimpleName() + "[", "]").add(
+                "address=" + address)
                 .add("addressSameAsRegisteredOfficeAddress=" + addressSameAsRegisteredOfficeAddress)
                 .add("appointedOn=" + appointedOn)
                 .add("countryOfResidence='" + countryOfResidence + "'")
@@ -192,12 +182,6 @@ public class OfficerFilingDto {
 
         public Builder() {
             this.buildSteps = new ArrayList<>();
-        }
-
-        public Builder id(final String value) {
-
-            buildSteps.add(data -> data.id = value);
-            return this;
         }
 
         public Builder address(final AddressDto value) {

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/OfficerFiling.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/OfficerFiling.java
@@ -119,7 +119,7 @@ public class OfficerFiling {
         return referenceEtag;
     }
 
-    public String getreferenceAppointmentId() {
+    public String getReferenceAppointmentId() {
         return referenceAppointmentId;
     }
 
@@ -156,8 +156,7 @@ public class OfficerFiling {
             return false;
         }
         final OfficerFiling that = (OfficerFiling) o;
-        return Objects.equals(getId(), that.getId())
-                && Objects.equals(getAddress(), that.getAddress())
+        return Objects.equals(getAddress(), that.getAddress())
                 && Objects.equals(getAddressSameAsRegisteredOfficeAddress(),
                 that.getAddressSameAsRegisteredOfficeAddress())
                 && Objects.equals(getAppointedOn(), that.getAppointedOn())
@@ -175,7 +174,7 @@ public class OfficerFiling {
                 && Objects.equals(getOccupation(), that.getOccupation())
                 && Objects.equals(getOfficerRole(), that.getOfficerRole())
                 && Objects.equals(getReferenceEtag(), that.getReferenceEtag())
-                && Objects.equals(getreferenceAppointmentId(), that.getreferenceAppointmentId())
+                && Objects.equals(getReferenceAppointmentId(), that.getReferenceAppointmentId())
                 && Objects.equals(getReferenceOfficerListEtag(), that.getReferenceOfficerListEtag())
                 && Objects.equals(getResignedOn(), that.getResignedOn())
                 && Objects.equals(getStatus(), that.getStatus())
@@ -187,11 +186,11 @@ public class OfficerFiling {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getAddress(), getAddressSameAsRegisteredOfficeAddress(),
+        return Objects.hash(getAddress(), getAddressSameAsRegisteredOfficeAddress(),
                 getAppointedOn(), getCountryOfResidence(), getCreatedAt(), getDateOfBirth(),
                 getFormerNames(), getIdentification(), getKind(), getLinks(), getName(),
                 getFirstName(), getLastName(), getNationality(), getOccupation(), getOfficerRole(),
-                getReferenceEtag(), getreferenceAppointmentId(), getReferenceOfficerListEtag(),
+                getReferenceEtag(), getReferenceAppointmentId(), getReferenceOfficerListEtag(),
                 getResignedOn(), getStatus(), getUpdatedAt(), getResidentialAddress(),
                 getResidentialAddressSameAsCorrespondenceAddress());
     }
@@ -265,7 +264,7 @@ public class OfficerFiling {
                     .occupation(other.getOccupation())
                     .officerRole(other.getOfficerRole())
                     .referenceEtag(other.getReferenceEtag())
-                    .referenceAppointmentId(other.getreferenceAppointmentId())
+                    .referenceAppointmentId(other.getReferenceAppointmentId())
                     .referenceOfficerListEtag(other.getReferenceOfficerListEtag())
                     .residentialAddress(other.getResidentialAddress())
                     .residentialAddressSameAsCorrespondenceAddress(

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerFilingMapper.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerFilingMapper.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.officerfiling.api.model.filing.FilingData;
 @Mapper(componentModel = "spring")
 public interface OfficerFilingMapper {
 
+    @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "kind", ignore = true)
     @Mapping(target = "links", ignore = true)

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.officerfiling.api.service;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.officerfiling.api.model.entity.Date3Tuple;
@@ -58,7 +57,7 @@ public class FilingDataServiceImpl implements FilingDataService {
 
         final var transaction = transactionService.getTransaction(transactionId, ericPassThroughHeader);
         String companyNumber = transaction.getCompanyNumber();
-        String appointmentId = officerFiling.getreferenceAppointmentId();
+        String appointmentId = officerFiling.getReferenceAppointmentId();
 
         final AppointmentFullRecordAPI companyAppointment = companyAppointmentService.getCompanyAppointment(companyNumber,
                 appointmentId, ericPassThroughHeader);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -65,7 +65,6 @@ public class FilingDataServiceImpl implements FilingDataService {
         var enhancedOfficerFiling = OfficerFiling.builder(officerFiling)
                 .dateOfBirth(new Date3Tuple(companyAppointment.getDateOfBirth()))
                 .name(companyAppointment.getName())
-                .referenceEtag(companyAppointment.getEtag())
                 .build();
 
         var filingData = filingMapper.mapFiling(enhancedOfficerFiling);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/utils/Constants.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.officerfiling.api.utils;
+
+public class Constants {
+
+    private Constants() {
+    }
+
+    // Request header names
+    public static final String ERIC_REQUEST_ID_KEY = "X-Request-Id";
+    public static final String ERIC_IDENTITY = "ERIC-identity";
+    public static final String ERIC_AUTHORISED_USER = "ERIC-Authorised-User";
+
+    // URI path attributes
+    public static final String TRANSACTION_ID_KEY = "transaction_id";
+
+    // Request attribute names
+    public static final String TRANSACTION_KEY = "transaction";
+
+    // URIs
+    public static final String VALIDATION_STATUS_URI_SUFFIX = "/validation-status";
+    public static final String TRANSACTIONS_PRIVATE_API_PREFIX = "/private/transactions/";
+    public static final String TRANSACTIONS_PUBLIC_API_PREFIX = "/transactions/";
+
+    // Filings
+    public static final String LINK_SELF = "self";
+    public static final String LINK_RESOURCE = "resource";
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
@@ -70,7 +70,7 @@ public class OfficerTerminationValidator {
         return new ApiErrors(errorList);
     }
 
-    private void validateSubmissionInformationInDate(HttpServletRequest request, OfficerFilingDto dto, AppointmentFullRecordAPI companyAppointment, List<ApiError> errorList) {
+    public void validateSubmissionInformationInDate(HttpServletRequest request, OfficerFilingDto dto, AppointmentFullRecordAPI companyAppointment, List<ApiError> errorList) {
         // If submission information is not out of date, the ETAG retrieved from the Company Appointments API and the ETAG passed from the request will match
         String companyAppointmentEtag = companyAppointment.getEtag();
         String requestEtag = dto.getReferenceEtag();

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/FilingDataControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/FilingDataControllerImplIT.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.companieshouse.officerfiling.api.controller.OfficerFilingControllerImplIT.tokenPermissions;
 
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +61,7 @@ class FilingDataControllerImplIT {
         when(filingDataService.generateOfficerFiling(TRANS_ID, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(filingApi);
 
         mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/filings", TRANS_ID, FILING_ID)
+                        .requestAttr("token_permissions",tokenPermissions)
             .headers(httpHeaders))
             .andDo(print())
             .andExpect(status().isOk())
@@ -74,7 +76,8 @@ class FilingDataControllerImplIT {
 
         mockMvc.perform(
                         get("/private/transactions/{id}/officers/{filingId}/filings", TRANS_ID,
-                                FILING_ID).headers(httpHeaders))
+                                FILING_ID).requestAttr(
+                                "token_permissions",tokenPermissions).headers(httpHeaders))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(status().reason(is("Resource not found")))

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplIT.java
@@ -62,6 +62,7 @@ class OfficerFilingControllerImplIT {
     private static final String COMPANY_NUMBER = "123456";
     public static final LocalDate INCORPORATION_DATE = LocalDate.of(2010, Month.OCTOBER, 20);
     public static final String DIRECTOR_NAME = "Director name";
+    private static final String ETAG = "etag";
 
     @MockBean
     private TransactionService transactionService;
@@ -98,6 +99,7 @@ class OfficerFilingControllerImplIT {
         companyProfileApi.setDateOfCreation(INCORPORATION_DATE);
         companyAppointment = new AppointmentFullRecordAPI();
         companyAppointment.setName(DIRECTOR_NAME);
+        companyAppointment.setEtag(ETAG);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
@@ -116,9 +116,11 @@ class OfficerFilingControllerImplTest {
         when(request.getRequestURI()).thenReturn(REQUEST_URI.toString());
         when(clock.instant()).thenReturn(FIRST_INSTANT);
         when(dto.getReferenceAppointmentId()).thenReturn(FILING_ID);
+        when(dto.getReferenceEtag()).thenReturn(ETAG);
         when(dto.getResignedOn()).thenReturn(LocalDate.of(2009, 10, 1));
         when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2005, 10, 3));
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
         when(filingMapper.map(dto)).thenReturn(filing);
         final var withFilingId = OfficerFiling.builder(filing).id(FILING_ID)
                 .build();

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
@@ -58,6 +58,7 @@ class OfficerFilingControllerImplTest {
     private static final Instant FIRST_INSTANT = Instant.parse("2022-10-15T09:44:08.108Z");
     public static final String COMPANY_NUMBER = "COMPANY_NUMBER";
     public static final String DIRECTOR_NAME = "director name";
+    private static final String ETAG = "etag";
 
     private OfficerFilingController testController;
     @Mock
@@ -195,6 +196,7 @@ class OfficerFilingControllerImplTest {
 
     @Test
     void doNotCreateFilingWhenRequestHasTooOldDate() {
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2021, 10, 3));
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -88,7 +88,7 @@ class OfficerFilingControllerImplValidationIT {
 
     @Test
     void createFilingWhenReferenceEtagBlankThenResponse400() throws Exception {
-        final var body = "{" + TM01_FRAGMENT.replace("etag", "") + "}";
+        final var body = "{" + TM01_FRAGMENT.replace("ETAG", "") + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
                         .contentType("application/json")

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -9,14 +9,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.companieshouse.officerfiling.api.model.entity.Links.PREFIX_PRIVATE;
 
 import java.net.URI;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -25,19 +23,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.officerfiling.api.model.entity.Links;
-import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
 import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerFilingMapper;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
 import uk.gov.companieshouse.officerfiling.api.service.TransactionService;
-import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @Tag("web")
 @WebMvcTest(controllers = OfficerFilingControllerImpl.class)
@@ -45,13 +39,14 @@ class OfficerFilingControllerImplValidationIT {
     private static final String TRANS_ID = "4f56fdf78b357bfc";
     private static final String FILING_ID = "632c8e65105b1b4a9f0d1f5e";
     private static final String PASSTHROUGH_HEADER = "passthrough";
-    private static final String TM01_FRAGMENT = "\"reference_etag\": \"etag_value\","
+    private static final String TM01_FRAGMENT = "\"reference_etag\": \"etag\","
             + "\"reference_appointment_id\": \"" + FILING_ID + "\","
             + "\"resigned_on\": \"2022-09-13\"";
     private static final URI REQUEST_URI = URI.create("/transactions/" + TRANS_ID + "/officers");
     private static final String COMPANY_NUMBER = "123456";
     public static final LocalDate INCORPORATION_DATE = LocalDate.of(2010, Month.OCTOBER, 20);
     public static final String DIRECTOR_NAME = "Director name";
+    private static final String ETAG = "etag";
 
     @MockBean
     private TransactionService transactionService;
@@ -88,11 +83,12 @@ class OfficerFilingControllerImplValidationIT {
         companyProfileApi.setDateOfCreation(INCORPORATION_DATE);
         companyAppointment = new AppointmentFullRecordAPI();
         companyAppointment.setName(DIRECTOR_NAME);
+        companyAppointment.setEtag(ETAG);
     }
 
     @Test
     void createFilingWhenReferenceEtagBlankThenResponse400() throws Exception {
-        final var body = "{" + TM01_FRAGMENT.replace("etag_value", "") + "}";
+        final var body = "{" + TM01_FRAGMENT.replace("etag", "") + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
                         .contentType("application/json")

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.companieshouse.officerfiling.api.controller.OfficerFilingControllerImplIT.tokenPermissions;
 
 import java.net.URI;
 import java.time.Clock;
@@ -91,6 +92,7 @@ class OfficerFilingControllerImplValidationIT {
         final var body = "{" + TM01_FRAGMENT.replace("ETAG", "") + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                        .requestAttr("token_permissions",tokenPermissions)
                         .contentType("application/json")
                         .headers(httpHeaders))
                 .andDo(print())
@@ -108,6 +110,7 @@ class OfficerFilingControllerImplValidationIT {
         final var body = "{" + TM01_FRAGMENT.replace(FILING_ID, "") + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                .requestAttr("token_permissions",tokenPermissions)
                 .contentType("application/json")
                 .headers(httpHeaders))
             .andDo(print())
@@ -125,6 +128,7 @@ class OfficerFilingControllerImplValidationIT {
         final var body = "{" + TM01_FRAGMENT.replace("2022-09-13", "") + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                        .requestAttr("token_permissions",tokenPermissions)
                         .contentType("application/json")
                         .headers(httpHeaders))
                 .andDo(print())
@@ -145,6 +149,7 @@ class OfficerFilingControllerImplValidationIT {
                 + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                        .requestAttr("token_permissions",tokenPermissions)
                         .contentType("application/json")
                         .headers(httpHeaders))
                 .andDo(print())
@@ -171,6 +176,7 @@ class OfficerFilingControllerImplValidationIT {
                 + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                        .requestAttr("token_permissions",tokenPermissions)
                         .contentType("application/json")
                         .headers(httpHeaders))
                 .andDo(print())
@@ -193,6 +199,7 @@ class OfficerFilingControllerImplValidationIT {
                 + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                        .requestAttr("token_permissions",tokenPermissions)
                         .contentType("application/json")
                         .headers(httpHeaders))
                 .andDo(print())
@@ -215,6 +222,7 @@ class OfficerFilingControllerImplValidationIT {
                 + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                        .requestAttr("token_permissions",tokenPermissions)
                         .contentType("application/json")
                         .headers(httpHeaders))
                 .andDo(print())
@@ -235,6 +243,7 @@ class OfficerFilingControllerImplValidationIT {
         final var body = "{" + TM01_FRAGMENT.replace("ETAG", "invalid") + "}";
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                .requestAttr("token_permissions",tokenPermissions)
                 .contentType("application/json")
                 .headers(httpHeaders))
             .andDo(print())

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -39,14 +39,14 @@ class OfficerFilingControllerImplValidationIT {
     private static final String TRANS_ID = "4f56fdf78b357bfc";
     private static final String FILING_ID = "632c8e65105b1b4a9f0d1f5e";
     private static final String PASSTHROUGH_HEADER = "passthrough";
-    private static final String TM01_FRAGMENT = "\"reference_etag\": \"etag\","
+    private static final String TM01_FRAGMENT = "\"reference_etag\": \"ETAG\","
             + "\"reference_appointment_id\": \"" + FILING_ID + "\","
             + "\"resigned_on\": \"2022-09-13\"";
     private static final URI REQUEST_URI = URI.create("/transactions/" + TRANS_ID + "/officers");
     private static final String COMPANY_NUMBER = "123456";
     public static final LocalDate INCORPORATION_DATE = LocalDate.of(2010, Month.OCTOBER, 20);
     public static final String DIRECTOR_NAME = "Director name";
-    private static final String ETAG = "etag";
+    private static final String ETAG = "ETAG";
 
     @MockBean
     private TransactionService transactionService;
@@ -224,5 +224,25 @@ class OfficerFilingControllerImplValidationIT {
                 .andExpect(jsonPath("$.errors[0].location_type", is("json-path")))
                 .andExpect(jsonPath("$.errors[0].error",
                         containsString("DateTimeParseException")));
+    }
+
+    @Test
+    void createFilingWhenReferenceEtagInvalid() throws Exception {
+        when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
+        when(companyAppointmentService.getCompanyAppointment(COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfileApi);
+
+        final var body = "{" + TM01_FRAGMENT.replace("ETAG", "invalid") + "}";
+
+        mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                .contentType("application/json")
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.errors", hasSize(1)))
+            .andExpect(jsonPath("$.errors[0].type", is("ch:validation")))
+            .andExpect(jsonPath("$.errors[0].location_type", is("json-path")))
+            .andExpect(jsonPath("$.errors[0].error",
+                containsString("The Officers information is out of date. Please start the process again and make a new submission")));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerFilingMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerFilingMapperTest.java
@@ -116,11 +116,11 @@ class OfficerFilingMapperTest {
         assertThat(filing.getName(), is("name"));
         assertThat(filing.getOfficerRole(), is(nullValue()));
         assertThat(filing.getReferenceEtag(), is("referenceEtag"));
-        assertThat(filing.getreferenceAppointmentId(), is("referenceAppointmentId"));
+        assertThat(filing.getReferenceAppointmentId(), is("referenceAppointmentId"));
         assertThat(filing.getNationality(), is("nation"));
         assertThat(filing.getOccupation(), is("work"));
         assertThat(filing.getReferenceEtag(), is("referenceEtag"));
-        assertThat(filing.getreferenceAppointmentId(), is("referenceAppointmentId"));
+        assertThat(filing.getReferenceAppointmentId(), is("referenceAppointmentId"));
         assertThat(filing.getReferenceOfficerListEtag(), is("list"));
         assertThat(filing.getResignedOn(), is(localDate1.atStartOfDay().toInstant(ZoneOffset.UTC)));
         assertThat(filing.getResidentialAddress(), is(equalTo(address)));

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -188,4 +188,34 @@ class OfficerTerminationValidatorTest {
                 .as("An error should not be produced when resignation date is the creation date")
                 .isEmpty();
     }
+
+    @Test
+    void validateSubmissionInformationInDateWhenValid() {
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
+        final var officerFilingDto = OfficerFilingDto.builder()
+            .referenceEtag("etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(LocalDate.of(2023, Month.JANUARY, 5))
+            .build();
+        officerTerminationValidator.validateSubmissionInformationInDate(request, officerFilingDto, companyAppointment, apiErrorsList);
+        assertThat(apiErrorsList)
+            .as("The Officers information is out of date. Please start the process again and make a new submission")
+            .isEmpty();
+    }
+
+    @Test
+    void validateSubmissionInformationInDateWhenInValid() {
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
+        final var officerFilingDto = OfficerFilingDto.builder()
+            .referenceEtag("invalid_etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(LocalDate.of(2023, Month.JANUARY, 5))
+            .build();
+        officerTerminationValidator.validateSubmissionInformationInDate(request, officerFilingDto, companyAppointment, apiErrorsList);
+        assertThat(apiErrorsList)
+            .as("An error should not be produced when the referenceEtag is invalid/ out of date")
+            .hasSize(1)
+            .extracting(ApiError::getError)
+            .contains("The Officers information is out of date. Please start the process again and make a new submission");
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -204,7 +204,7 @@ class OfficerTerminationValidatorTest {
     }
 
     @Test
-    void validateSubmissionInformationInDateWhenInValid() {
+    void validateSubmissionInformationInDateWhenInvalid() {
         when(companyAppointment.getEtag()).thenReturn(ETAG);
         final var officerFilingDto = OfficerFilingDto.builder()
             .referenceEtag("invalid_etag")

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -199,7 +199,7 @@ class OfficerTerminationValidatorTest {
             .build();
         officerTerminationValidator.validateSubmissionInformationInDate(request, officerFilingDto, companyAppointment, apiErrorsList);
         assertThat(apiErrorsList)
-            .as("The Officers information is out of date. Please start the process again and make a new submission")
+            .as("An error should not be produced when the referenceEtag is valid/ in date")
             .isEmpty();
     }
 
@@ -213,7 +213,7 @@ class OfficerTerminationValidatorTest {
             .build();
         officerTerminationValidator.validateSubmissionInformationInDate(request, officerFilingDto, companyAppointment, apiErrorsList);
         assertThat(apiErrorsList)
-            .as("An error should not be produced when the referenceEtag is invalid/ out of date")
+            .as("An error should be produced when the referenceEtag is invalid/ out of date")
             .hasSize(1)
             .extracting(ApiError::getError)
             .contains("The Officers information is out of date. Please start the process again and make a new submission");

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -32,6 +32,7 @@ class OfficerTerminationValidatorTest {
     private static final String PASSTHROUGH_HEADER = "passthrough";
     private static final String COMPANY_NUMBER = "COMPANY_NUMBER";
     private static final String DIRECTOR_NAME = "director name";
+    private static final String ETAG = "etag";
 
     private OfficerTerminationValidator officerTerminationValidator;
     private List<ApiError> apiErrorsList;
@@ -66,6 +67,8 @@ class OfficerTerminationValidatorTest {
                 .referenceAppointmentId(FILING_ID)
                 .resignedOn(LocalDate.of(2022, 9, 13))
                 .build();
+
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2021, 10, 3));
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
@@ -85,6 +88,7 @@ class OfficerTerminationValidatorTest {
                 .referenceAppointmentId(FILING_ID)
                 .resignedOn(LocalDate.of(1022, 9, 13))
                 .build();
+
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2021, 10, 3));
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
@@ -94,7 +98,7 @@ class OfficerTerminationValidatorTest {
         final var apiErrors = officerTerminationValidator.validate(request, dto, TRANS_ID, PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("Each validation error should have been raised")
-                .hasSize(2)
+                .hasSize(3)
                 .extracting(ApiError::getLocationType, ApiError::getType)
                 .containsOnly(tuple("json-path", "ch:validation"));
     }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -86,7 +86,6 @@ class OfficerTerminationValidatorTest {
                 .resignedOn(LocalDate.of(1022, 9, 13))
                 .build();
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
-
         when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2021, 10, 3));
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
         when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfile);


### PR DESCRIPTION
Add an interceptor to check a user has the correct permissions needed for a TM01 request.
This is a stopgap until the permissions interceptor available in api-security-java has been updated to account for the requirements of officer-filing-api. https://companieshouse.atlassian.net/browse/DACT-145?focusedCommentId=206572
https://companieshouse.atlassian.net/browse/DACT-145
Relies on changes made in https://github.com/companieshouse/api-security-java/pull/33 