### PR TITLE
DACT-288 Undo immutable logMap

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/utils/LogHelper.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/utils/LogHelper.java
@@ -119,7 +119,7 @@ public final class LogHelper {
         }
 
         public Map<String, Object> build() {
-            return Collections.unmodifiableMap(logMap);
+            return logMap;
         }
         
         private void addToLogMap(Key key, String field) {


### PR DESCRIPTION
LogMap was previously made immutable as a builder was introduced to populate the fields. I forgot that when this logMap is sent to structured-logging, more fields will be added at that point which caused the system to fall over.