### PR TITLE
Dact 354 create validation endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import static uk.gov.companieshouse.officerfiling.api.model.entity.Links.PREFIX_PRIVATE;
 
 @RestController
 @RequestMapping("/transactions/{transactionId}/officers")
@@ -168,13 +167,11 @@ public class OfficerFilingControllerImpl implements OfficerFilingController {
     private Links buildLinks(final OfficerFiling savedFiling, final HttpServletRequest request) {
         final var objectId = new ObjectId(Objects.requireNonNull(savedFiling.getId()));
         final var uriBuilder = UriComponentsBuilder.fromUriString(request.getRequestURI())
-                .pathSegment(objectId.toHexString());
+            .pathSegment(objectId.toHexString());
         final var selfUri = uriBuilder.build().toUri();
-        final var privateUriBuilder =
-                UriComponentsBuilder.fromUriString(PREFIX_PRIVATE + "/" + request.getRequestURI())
-                        .pathSegment(objectId.toHexString());
-        final var validateUri = privateUriBuilder.pathSegment(VALIDATION_STATUS)
-                .build().toUri();
+
+        final var validateUri = uriBuilder.pathSegment(VALIDATION_STATUS)
+            .build().toUri();
 
         return new Links(selfUri, validateUri);
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
@@ -11,7 +11,7 @@ import uk.gov.companieshouse.officerfiling.api.model.entity.Links;
 
 public interface ValidationStatusController {
     /**
-     * Controller endpoint: Perform final validation checks.
+     * Controller endpoint: Perform validation checks.
      * Handle requests from the Transaction service attempting to close a Transaction belonging
      * to this Filing resource.
      * This endpoint's URI is provided by the Filing resource in
@@ -22,27 +22,11 @@ public interface ValidationStatusController {
      * @param request        the servlet request
      * @throws NotImplementedException implementing classes must perform work
      */
-    @GetMapping
-    default ValidationStatusResponse validatePrivate(@RequestAttribute("transaction") Transaction transaction,
+    @GetMapping(value = "/{filingResourceId}/validation_status", produces = {"application/json"})
+    default ValidationStatusResponse validate(@RequestAttribute("transaction") Transaction transaction,
         @PathVariable("filingResourceId") String filingResourceId,
         HttpServletRequest request) {
         throw new NotImplementedException();
     }
 
-    /**
-     * Controller endpoint: Perform validation checks.
-     * This endpoint's URI is provided by the Filing resource in
-     * {@link Links#getValidationStatus()}.
-     *
-     * @param transaction        the Transaction ID
-     * @param filingResourceId the Filing resource ID
-     * @param request        the servlet request
-     * @throws NotImplementedException implementing classes must perform work
-     */
-    @GetMapping
-    default ValidationStatusResponse validatePublic(@RequestAttribute("transaction") Transaction transaction,
-        @PathVariable("filingResourceId") String filingResourceId,
-        HttpServletRequest request) {
-        throw new NotImplementedException();
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusController.java
@@ -3,6 +3,8 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
 import uk.gov.companieshouse.officerfiling.api.model.entity.Links;
@@ -15,16 +17,32 @@ public interface ValidationStatusController {
      * This endpoint's URI is provided by the Filing resource in
      * {@link Links#getValidationStatus()}.
      *
-     * @param transId        the Transaction ID
-     * @param filingResource the Filing resource ID
+     * @param transaction        the Transaction ID
+     * @param filingResourceId the Filing resource ID
      * @param request        the servlet request
      * @throws NotImplementedException implementing classes must perform work
      */
-    @GetMapping(value = "/{filingResourceId}/validation_status", produces = {"application/json"})
-    default ValidationStatusResponse validate(@PathVariable("transactionId") String transId,
-            @PathVariable("filingResourceId") String filingResource,
-            final HttpServletRequest request) {
+    @GetMapping
+    default ValidationStatusResponse validatePrivate(@RequestAttribute("transaction") Transaction transaction,
+        @PathVariable("filingResourceId") String filingResourceId,
+        HttpServletRequest request) {
         throw new NotImplementedException();
     }
 
+    /**
+     * Controller endpoint: Perform validation checks.
+     * This endpoint's URI is provided by the Filing resource in
+     * {@link Links#getValidationStatus()}.
+     *
+     * @param transaction        the Transaction ID
+     * @param filingResourceId the Filing resource ID
+     * @param request        the servlet request
+     * @throws NotImplementedException implementing classes must perform work
+     */
+    @GetMapping
+    default ValidationStatusResponse validatePublic(@RequestAttribute("transaction") Transaction transaction,
+        @PathVariable("filingResourceId") String filingResourceId,
+        HttpServletRequest request) {
+        throw new NotImplementedException();
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
@@ -66,7 +66,7 @@ public class ValidationStatusControllerImpl implements ValidationStatusControlle
         @PathVariable("filingResourceId") final String filingResourceId,
         final HttpServletRequest request) {
 
-        logger.debugContext(transaction.getId(), "GET validation request", new LogHelper.Builder(transaction.getId())
+        logger.debugContext(transaction.getId(), "GET validation request", new LogHelper.Builder(transaction)
                 .withFilingId(filingResourceId)
                 .withRequest(request)
                 .build());

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
@@ -1,61 +1,133 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
 import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
+import uk.gov.companieshouse.officerfiling.api.model.mapper.ErrorMapper;
+import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerFilingMapper;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
+import uk.gov.companieshouse.officerfiling.api.service.TransactionService;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
+import uk.gov.companieshouse.officerfiling.api.validation.OfficerTerminationValidator;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @RestController
-@RequestMapping("/private/transactions/{transactionId}/officers")
 public class ValidationStatusControllerImpl implements ValidationStatusController {
     private final OfficerFilingService officerFilingService;
     private final Logger logger;
+    private final TransactionService transactionService;
+    private final CompanyProfileService companyProfileService;
+    private final CompanyAppointmentService companyAppointmentService;
+    private final OfficerFilingMapper officerFilingMapper;
+    private final ErrorMapper errorMapper;
 
-    public ValidationStatusControllerImpl(OfficerFilingService officerFilingService, Logger logger) {
+    public ValidationStatusControllerImpl(OfficerFilingService officerFilingService, Logger logger,
+        TransactionService transactionService, CompanyProfileService companyProfileService,
+        CompanyAppointmentService companyAppointmentService, OfficerFilingMapper officerFilingMapper,
+        ErrorMapper errorMapper) {
         this.officerFilingService = officerFilingService;
         this.logger = logger;
+        this.transactionService = transactionService;
+        this.companyProfileService = companyProfileService;
+        this.companyAppointmentService = companyAppointmentService;
+        this.officerFilingMapper = officerFilingMapper;
+        this.errorMapper = errorMapper;
     }
 
     /**
      * Controller endpoint: Perform final validation checks.
      * Provisional behaviour: return TRUE response until details of requirements known.
      *
-     * @param transId        the Transaction ID
+     * @param transaction        the Transaction
      * @param filingResourceId the Filing resource ID
      * @param request        the servlet request
      * @return ValidationResponse of TRUE (provisional)
      */
     @Override
     @ResponseBody
-    @ResponseStatus(HttpStatus.OK)
-    @GetMapping(value = "/{filingResourceId}/validation_status", produces = {"application/json"})
-    public ValidationStatusResponse validate(@PathVariable("transactionId") final String transId,
-            @PathVariable("filingResourceId") final String filingResourceId,
-            final HttpServletRequest request) {
+    @RequestMapping(value = "private/transactions/{transactionId}/officers/{filingResourceId}/validation_status",
+        method = RequestMethod.GET)
+    public ValidationStatusResponse validatePrivate(
+        @RequestAttribute("transaction") Transaction transaction,
+        @PathVariable("filingResourceId") final String filingResourceId,
+        final HttpServletRequest request) {
 
-        logger.debugContext(transId, "GET validation request", new LogHelper.Builder(transId)
+        logger.debugContext(transaction.getId(), "GET private validation request", new LogHelper.Builder(transaction.getId())
                 .withFilingId(filingResourceId)
                 .withRequest(request)
                 .build());
 
-        var maybeOfficerFiling = officerFilingService.get(filingResourceId, transId);
+        final var passthroughHeader =
+            request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
 
-        return maybeOfficerFiling.map(this::isValid).orElseThrow(ResourceNotFoundException::new);
+        return validate(request, filingResourceId, transaction, passthroughHeader);
     }
 
-    // TODO: apply proper validation requirements
-    private ValidationStatusResponse isValid(OfficerFiling officerFiling) {
+    /**
+     * Controller endpoint: Perform validation checks after patch.
+     *
+     * @param transaction        the Transaction
+     * @param filingResourceId the Filing resource ID
+     * @param request        the servlet request
+     * @return ValidationResponse of TRUE (provisional)
+     */
+    @Override
+    @ResponseBody
+    @RequestMapping(value = "/transactions/{transactionId}/officers/{filingResourceId}/validation_status",
+        method = RequestMethod.GET)
+    public ValidationStatusResponse validatePublic(
+        @RequestAttribute("transaction") Transaction transaction,
+        @PathVariable("filingResourceId") final String filingResourceId,
+        final HttpServletRequest request) {
+
+        logger.debugContext(transaction.getId(), "GET public validation request", new LogHelper.Builder(transaction.getId())
+            .withFilingId(filingResourceId)
+            .withRequest(request)
+            .build());
+
+        final var passthroughHeader =
+            request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+
+        return validate(request, filingResourceId, transaction, passthroughHeader);
+    }
+
+    ValidationStatusResponse validate(HttpServletRequest request, String filingResourceId,
+        Transaction transaction, String passthroughHeader) {
+
+        Optional<OfficerFiling> maybeOfficerFiling = officerFilingService.get(filingResourceId, transaction.getId());
+
+        return maybeOfficerFiling.map(officerFiling -> isValid(request, officerFilingMapper.map(officerFiling), transaction, passthroughHeader))
+            .orElseThrow(() -> new ResourceNotFoundException(
+                "Filing resource not found: " + filingResourceId));
+    }
+
+    private ValidationStatusResponse isValid(HttpServletRequest request, OfficerFilingDto officerFiling,
+        Transaction transaction, String passthroughHeader) {
         var validationStatus = new ValidationStatusResponse();
+
+        final var validator = new OfficerTerminationValidator(logger, transactionService, companyProfileService, companyAppointmentService);
+        final ApiErrors validationErrors  = validator.validate(request, officerFiling, transaction, passthroughHeader);
+
+        if(validationErrors.hasErrors()) {
+            validationStatus.setValidationStatusError(errorMapper.map(
+                validationErrors.getErrors()));
+            return validationStatus;
+        }
+
         validationStatus.setValid(true);
         return validationStatus;
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/ErrorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/ErrorMapper.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.officerfiling.api.model.mapper;
+
+import java.util.Set;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import uk.gov.companieshouse.api.error.ApiError;
+import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
+import uk.gov.companieshouse.officerfiling.api.error.ErrorType;
+import uk.gov.companieshouse.officerfiling.api.error.LocationType;
+
+@Mapper(componentModel = "spring", imports = {ErrorType.class, LocationType.class})
+public interface ErrorMapper {
+    @Mapping(target = "error", source = "error")
+    @Mapping(target="type", expression = "java(ErrorType.VALIDATION.getType())")
+    @Mapping(target="location", expression = "java(\"$.\" + apiError.getLocation())")
+    @Mapping(target="locationType", expression = "java(LocationType.JSON_PATH.getValue())")
+    ValidationStatusError map(final ApiError apiError);
+
+    ValidationStatusError[] map(final Set<ApiError> apiErrors);
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
@@ -106,9 +106,8 @@ class OfficerFilingControllerImplTest {
                 .resignedOn(Instant.parse("2022-09-13T00:00:00Z"))
                 .build();
         final var builder = UriComponentsBuilder.fromUri(REQUEST_URI);
-        final var privateBuilder = UriComponentsBuilder.fromUri(URI.create(PREFIX_PRIVATE + "/" + REQUEST_URI));
         links = new Links(builder.pathSegment(FILING_ID)
-                .build().toUri(), privateBuilder.pathSegment(FILING_ID).pathSegment("validation_status")
+                .build().toUri(), builder.pathSegment("validation_status")
                 .build().toUri());
         resourceMap = createResources();
     }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
@@ -1,27 +1,44 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.companieshouse.api.interceptor.OpenTransactionInterceptor;
-import uk.gov.companieshouse.api.interceptor.TransactionInterceptor;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler;
+import uk.gov.companieshouse.api.handler.transaction.request.TransactionsGet;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.api.util.security.InvalidTokenPermissionException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 
@@ -31,10 +48,12 @@ class ValidationStatusControllerImplIT {
     private static final String TRANS_ID = "4f56fdf78b357bfc";
     private static final String FILING_ID = "632c8e65105b1b4a9f0d1f5e";
     private static final String PASSTHROUGH_HEADER = "passthrough";
-    @MockBean
-    private TransactionInterceptor transactionInterceptor;
-    @MockBean
-    private OpenTransactionInterceptor openTransactionInterceptor;
+    private static final String COMPANY_NUMBER = "123456";
+    public static final LocalDate INCORPORATION_DATE = LocalDate.of(2010, Month.OCTOBER, 20);
+    public static final LocalDate APPOINTMENT_DATE = LocalDate.of(2010, Month.OCTOBER, 30);
+    public static final String DIRECTOR_NAME = "Director name";
+    private static final String ETAG = "etag";
+    private static final String COMPANY_TYPE = "ltd";
     @MockBean
     private OfficerFilingService officerFilingService;
     @MockBean
@@ -43,26 +62,67 @@ class ValidationStatusControllerImplIT {
     private Logger logger;
     @MockBean
     private LogHelper logHelper;
+    @MockBean
+    private ApiClientService apiClientService;
+    @MockBean
+    private CompanyProfileService companyProfileService;
+    @MockBean
+    private CompanyAppointmentService companyAppointmentService;
+    @Mock
+    private ApiClient apiClientMock;
+    @Mock
+    private TransactionsResourceHandler transactionResourceHandlerMock;
+    @Mock
+    private TransactionsGet transactionGetMock;
+    @Mock
+    private ApiResponse<Transaction> apiResponse;
 
     private HttpHeaders httpHeaders;
+    private Transaction transaction;
+    private CompanyProfileApi companyProfileApi;
+    private AppointmentFullRecordAPI companyAppointment;
 
     @Autowired
     private MockMvc mockMvc;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws InvalidTokenPermissionException, IOException, URIValidationException {
         httpHeaders = new HttpHeaders();
         httpHeaders.add("ERIC-Access-Token", PASSTHROUGH_HEADER);
-        when(transactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
-        when(openTransactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        httpHeaders.add("ERIC-Authorised-Token-Permissions", "company_officers=readprotected,delete");
+
+        transaction = new Transaction();
+        transaction.setCompanyNumber(COMPANY_NUMBER);
+        transaction.setId(TRANS_ID);
+        transaction.setStatus(TransactionStatus.OPEN);
+        companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setDateOfCreation(INCORPORATION_DATE);
+        companyProfileApi.setType(COMPANY_TYPE);
+        companyAppointment = new AppointmentFullRecordAPI();
+        companyAppointment.setName(DIRECTOR_NAME);
+        companyAppointment.setAppointedOn(APPOINTMENT_DATE);
+        companyAppointment.setEtag(ETAG);
+
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClientMock);
+        when(apiClientMock.transactions()).thenReturn(transactionResourceHandlerMock);
+        when(transactionResourceHandlerMock.get(anyString())).thenReturn(transactionGetMock);
+        when(transactionGetMock.execute()).thenReturn(apiResponse);
+        when(apiResponse.getData()).thenReturn(transaction);
     }
 
     @Test
-    void validationStatusWhenFound() throws Exception {
-        final var filing = OfficerFiling.builder().build();
-        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+    void publicValidationStatusWhenFoundAndNoValidationErrors() throws Exception {
+        final var filing = OfficerFiling.builder()
+            .referenceEtag("etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(Instant.parse("2022-09-13T00:00:00Z"))
+            .build();
 
-        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID, request)
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfileApi);
+
+        mockMvc.perform(get("/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID)
             .headers(httpHeaders))
             .andDo(print())
             .andExpect(status().isOk())
@@ -70,13 +130,53 @@ class ValidationStatusControllerImplIT {
     }
 
     @Test
-    void validationStatusWhenNotFound() throws Exception {
+    void privateValidationStatusWhenFoundAndNoValidationErrors() throws Exception {
+        final var filing = OfficerFiling.builder()
+            .referenceEtag("etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(Instant.parse("2022-09-13T00:00:00Z"))
+            .build();
+
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfileApi);
+
+        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.is_valid", is(true)));
+    }
+
+    @Test
+    void publicValidationStatusWhenNotFound() throws Exception {
         when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.empty());
 
-        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID, request)
+        mockMvc.perform(get("/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID, request)
                         .headers(httpHeaders))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$").doesNotExist());
+    }
+
+    @Test
+    void publicValidationStatusWhenFoundAndEtagValidationError() throws Exception {
+        final var filing = OfficerFiling.builder()
+            .referenceEtag("invalid_etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(Instant.parse("2022-09-13T00:00:00Z"))
+            .build();
+
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfileApi);
+
+        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.is_valid", is(false)))
+            .andExpect(jsonPath("$.errors[0].error", containsString(
+                "The Officers information is out of date. Please start the process again and make a new submission")));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.google.api.client.http.HttpResponseException;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -25,6 +27,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler;
 import uk.gov.companieshouse.api.handler.transaction.request.TransactionsGet;
@@ -76,6 +79,8 @@ class ValidationStatusControllerImplIT {
     private TransactionsGet transactionGetMock;
     @Mock
     private ApiResponse<Transaction> apiResponse;
+    @Mock
+    private HttpResponseException.Builder builder;
 
     private HttpHeaders httpHeaders;
     private Transaction transaction;
@@ -171,12 +176,35 @@ class ValidationStatusControllerImplIT {
         when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
         when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfileApi);
 
-        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID)
+        mockMvc.perform(get("/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID)
                 .headers(httpHeaders))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.is_valid", is(false)))
             .andExpect(jsonPath("$.errors[0].error", containsString(
                 "The Officers information is out of date. Please start the process again and make a new submission")));
+    }
+
+    @Test
+    void publicValidationStatusWhenTransactionNotFound() throws Exception {
+        final var filing = OfficerFiling.builder()
+            .referenceEtag("invalid_etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(Instant.parse("2022-09-13T00:00:00Z"))
+            .build();
+
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClientMock);
+        when(apiClientMock.transactions()).thenReturn(transactionResourceHandlerMock);
+        when(transactionResourceHandlerMock.get(anyString())).thenReturn(transactionGetMock);
+        when(transactionGetMock.execute()).thenThrow(URIValidationException.class);
+
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfileApi);
+
+        mockMvc.perform(get("/transactions/{id}/officers/{filingId}/validation_status", TRANS_ID, FILING_ID)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isInternalServerError());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
@@ -48,9 +48,9 @@ class ValidationStatusControllerImplIT {
     private static final String FILING_ID = "632c8e65105b1b4a9f0d1f5e";
     private static final String PASSTHROUGH_HEADER = "passthrough";
     private static final String COMPANY_NUMBER = "123456";
-    public static final LocalDate INCORPORATION_DATE = LocalDate.of(2010, Month.OCTOBER, 20);
-    public static final LocalDate APPOINTMENT_DATE = LocalDate.of(2010, Month.OCTOBER, 30);
-    public static final String DIRECTOR_NAME = "Director name";
+    private static final LocalDate INCORPORATION_DATE = LocalDate.of(2010, Month.OCTOBER, 20);
+    private static final LocalDate APPOINTMENT_DATE = LocalDate.of(2010, Month.OCTOBER, 30);
+    private static final String DIRECTOR_NAME = "Director name";
     private static final String ETAG = "etag";
     private static final String COMPANY_TYPE = "ltd";
     @MockBean

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
@@ -35,11 +35,11 @@ import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 @ExtendWith(MockitoExtension.class)
 class ValidationStatusControllerImplTest {
 
-    public static final String TRANS_ID = "117524-754816-491724";
-    public static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
+    private static final String TRANS_ID = "117524-754816-491724";
+    private static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
     private static final String ETAG = "etag";
     private static final String COMPANY_TYPE = "ltd";
-    public static final String COMPANY_NUMBER = "COMPANY_NUMBER";
+    private static final String COMPANY_NUMBER = "COMPANY_NUMBER";
     private static final String PASSTHROUGH_HEADER = "passthrough";
     @Mock
     private OfficerFilingService officerFilingService;

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
@@ -1,10 +1,13 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,17 +15,30 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
+import uk.gov.companieshouse.officerfiling.api.model.mapper.ErrorMapper;
+import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerFilingMapper;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
-import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
+import uk.gov.companieshouse.officerfiling.api.service.TransactionService;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @ExtendWith(MockitoExtension.class)
 class ValidationStatusControllerImplTest {
 
     public static final String TRANS_ID = "117524-754816-491724";
     public static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
+    private static final String ETAG = "etag";
+    private static final String COMPANY_TYPE = "ltd";
+    public static final String COMPANY_NUMBER = "COMPANY_NUMBER";
+    private static final String PASSTHROUGH_HEADER = "passthrough";
     @Mock
     private OfficerFilingService officerFilingService;
     @Mock
@@ -30,28 +46,202 @@ class ValidationStatusControllerImplTest {
     @Mock
     private Logger logger;
     @Mock
-    private LogHelper logHelper;
-
+    private TransactionService transactionService;
+    @Mock
+    private CompanyProfileService companyProfileService;
+    @Mock
+    private CompanyAppointmentService companyAppointmentService;
+    @Mock
+    private OfficerFilingMapper officerFilingMapper;
+    @Mock
+    private ErrorMapper errorMapper;
+    @Mock
+    private Transaction transaction;
+    @Mock
+    private AppointmentFullRecordAPI companyAppointment;
+    @Mock
+    private CompanyProfileApi companyProfile;
+    @Mock
+    private OfficerFilingDto dto;
+    private OfficerFiling filing;
     private ValidationStatusControllerImpl testController;
 
     @BeforeEach
     void setUp() {
-        testController = new ValidationStatusControllerImpl(officerFilingService, logger);
+        testController = new ValidationStatusControllerImpl(officerFilingService, logger,
+            transactionService, companyProfileService, companyAppointmentService, officerFilingMapper,
+            errorMapper);
+        filing = OfficerFiling.builder()
+            .referenceAppointmentId("off-id")
+            .referenceEtag("etag")
+            .resignedOn(Instant.parse("2022-09-13T00:00:00Z"))
+            .build();
     }
 
     @Test
-    void validateWhenFound() {
-        var filing = OfficerFiling.builder().build();
-        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
-        final var response= testController.validate(TRANS_ID, FILING_ID, request);
+    void validateWhenFilingFoundAndNoValidationErrors() {
 
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(officerFilingMapper.map(filing)).thenReturn(dto);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(dto.getReferenceEtag()).thenReturn(ETAG);
+        when(dto.getReferenceAppointmentId()).thenReturn(FILING_ID);
+        when(dto.getResignedOn()).thenReturn(LocalDate.of(2009, 10, 1));
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2005, 10, 3));
+        when(companyProfile.getType()).thenReturn(COMPANY_TYPE);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfile);
+        when(companyAppointment.getAppointedOn()).thenReturn(LocalDate.of(2007, 10, 5));
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+
+        final var response= testController.validate(request, FILING_ID, transaction, PASSTHROUGH_HEADER);
+        assertThat(response.getValidationStatusError(), is(nullValue()));
         assertThat(response.isValid(), is(true));
     }
 
     @Test
-    void validateWhenNotFound() {
-        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.empty());
+    void validatePublicWhenFilingFoundAndNoValidationErrors() {
 
-        assertThrows(ResourceNotFoundException.class, () -> testController.validate(TRANS_ID, FILING_ID, request));
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(officerFilingMapper.map(filing)).thenReturn(dto);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+        when(dto.getReferenceEtag()).thenReturn(ETAG);
+        when(dto.getReferenceAppointmentId()).thenReturn(FILING_ID);
+        when(dto.getResignedOn()).thenReturn(LocalDate.of(2009, 10, 1));
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2005, 10, 3));
+        when(companyProfile.getType()).thenReturn(COMPANY_TYPE);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfile);
+        when(companyAppointment.getAppointedOn()).thenReturn(LocalDate.of(2007, 10, 5));
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+
+        final var response= testController.validatePublic(transaction, FILING_ID, request);
+        assertThat(response.getValidationStatusError(), is(nullValue()));
+        assertThat(response.isValid(), is(true));
     }
+
+    @Test
+    void validatePrivateWhenFilingFoundAndNoValidationErrors() {
+
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(officerFilingMapper.map(filing)).thenReturn(dto);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+        when(dto.getReferenceEtag()).thenReturn(ETAG);
+        when(dto.getReferenceAppointmentId()).thenReturn(FILING_ID);
+        when(dto.getResignedOn()).thenReturn(LocalDate.of(2009, 10, 1));
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2005, 10, 3));
+        when(companyProfile.getType()).thenReturn(COMPANY_TYPE);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfile);
+        when(companyAppointment.getAppointedOn()).thenReturn(LocalDate.of(2007, 10, 5));
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+
+        final var response= testController.validatePrivate(transaction, FILING_ID, request);
+        assertThat(response.getValidationStatusError(), is(nullValue()));
+        assertThat(response.isValid(), is(true));
+    }
+
+    @Test
+    void validateWhenFilingFoundAndValidationErrors() {
+
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(officerFilingMapper.map(filing)).thenReturn(dto);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(dto.getReferenceEtag()).thenReturn("etag");
+        when(dto.getReferenceAppointmentId()).thenReturn(FILING_ID);
+        when(dto.getResignedOn()).thenReturn(LocalDate.of(1022, 9, 13));
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2021, 10, 3));
+        when(companyProfile.getType()).thenReturn("invalid-type");
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfile);
+        when(companyAppointment.getAppointedOn()).thenReturn(LocalDate.of(2021, 10, 5));
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+
+        final var response= testController.validate(request, FILING_ID, transaction, PASSTHROUGH_HEADER);
+        assertThat(response.isValid(), is(false));
+    }
+
+    @Test
+    void validatePublicWhenFilingFoundAndValidationErrors() {
+
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(officerFilingMapper.map(filing)).thenReturn(dto);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+        when(dto.getReferenceEtag()).thenReturn("etag");
+        when(dto.getReferenceAppointmentId()).thenReturn(FILING_ID);
+        when(dto.getResignedOn()).thenReturn(LocalDate.of(1022, 9, 13));
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2021, 10, 3));
+        when(companyProfile.getType()).thenReturn("invalid-type");
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfile);
+        when(companyAppointment.getAppointedOn()).thenReturn(LocalDate.of(2021, 10, 5));
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+
+        final var response= testController.validatePublic(transaction, FILING_ID, request);
+        assertThat(response.isValid(), is(false));
+    }
+
+    @Test
+    void validatePrivateWhenFilingFoundAndValidationErrors() {
+
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(officerFilingMapper.map(filing)).thenReturn(dto);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+        when(dto.getReferenceEtag()).thenReturn("etag");
+        when(dto.getReferenceAppointmentId()).thenReturn(FILING_ID);
+        when(dto.getResignedOn()).thenReturn(LocalDate.of(1022, 9, 13));
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyProfile.getDateOfCreation()).thenReturn(LocalDate.of(2021, 10, 3));
+        when(companyProfile.getType()).thenReturn("invalid-type");
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfile);
+        when(companyAppointment.getAppointedOn()).thenReturn(LocalDate.of(2021, 10, 5));
+        when(companyAppointment.getEtag()).thenReturn(ETAG);
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
+
+        final var response= testController.validatePrivate(transaction, FILING_ID, request);
+        assertThat(response.isValid(), is(false));
+    }
+
+    @Test
+    void validateWhenFilingNotFound() {
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.empty());
+        when(transaction.getId()).thenReturn(TRANS_ID);
+
+        assertThrows(ResourceNotFoundException.class, () -> testController.validate(request, FILING_ID, transaction, PASSTHROUGH_HEADER));
+    }
+
+    @Test
+    void validatePublicWhenFilingNotFound() {
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.empty());
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+
+        assertThrows(ResourceNotFoundException.class, () -> testController.validatePublic(transaction, FILING_ID, request));
+    }
+
+    @Test
+    void validatePrivateWhenFilingNotFound() {
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.empty());
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+
+        assertThrows(ResourceNotFoundException.class, () -> testController.validatePrivate(transaction, FILING_ID, request));
+    }
+
+
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerTest.java
@@ -22,19 +22,8 @@ class ValidationStatusControllerTest {
 
     @Test
     void validate() {
-        assertThrows(NotImplementedException.class, () -> testController.validatePrivate(
+        assertThrows(NotImplementedException.class, () -> testController.validate(
             transaction,"6332aa6ed28ad2333c3a520a", request));
     }
 
-    @Test
-    void validatePublic() {
-        assertThrows(NotImplementedException.class, () -> testController.validatePublic(
-            transaction,"6332aa6ed28ad2333c3a520a", request));
-    }
-
-    @Test
-    void validatePrivate() {
-        assertThrows(NotImplementedException.class, () -> testController.validatePublic(
-            transaction,"6332aa6ed28ad2333c3a520a", request));
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerTest.java
@@ -4,20 +4,37 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
 
+@ExtendWith(MockitoExtension.class)
 class ValidationStatusControllerTest {
 
+    private final ValidationStatusController testController = new ValidationStatusController() {
+    };
     @Mock
     private HttpServletRequest request;
+    @Mock
+    private Transaction transaction;
 
     @Test
     void validate() {
+        assertThrows(NotImplementedException.class, () -> testController.validatePrivate(
+            transaction,"6332aa6ed28ad2333c3a520a", request));
+    }
 
-        var testController = new ValidationStatusController() {};
+    @Test
+    void validatePublic() {
+        assertThrows(NotImplementedException.class, () -> testController.validatePublic(
+            transaction,"6332aa6ed28ad2333c3a520a", request));
+    }
 
-        assertThrows(NotImplementedException.class, () -> testController.validate("trans-id", "filing-id", request));
-
+    @Test
+    void validatePrivate() {
+        assertThrows(NotImplementedException.class, () -> testController.validatePublic(
+            transaction,"6332aa6ed28ad2333c3a520a", request));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/model/mapper/ErrorMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/model/mapper/ErrorMapperTest.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.officerfiling.api.model.mapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.error.ApiError;
+import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
+
+@ExtendWith(MockitoExtension.class)
+class ErrorMapperTest {
+    private ErrorMapper testMapper;
+
+    private ApiError apiError;
+
+    @BeforeEach
+    void setUp() {
+        testMapper = Mappers.getMapper(ErrorMapper.class);
+        apiError = new ApiError("message", "field", "json-path", "ch:validation");
+    }
+
+    @Test
+    void mapFieldError() {
+        final var validationStatusError = testMapper.map(apiError);
+        final var expectedError =
+                new ValidationStatusError("message", "$.field", "json-path", "ch:validation");
+
+        assertThat(validationStatusError, samePropertyValuesAs(expectedError));
+    }
+
+    @Test
+    void mapFieldErrorWhenNull() {
+        assertThat(testMapper.map((ApiError) null), is(nullValue()));
+    }
+
+    @Test
+    void mapFieldErrorList() {
+        final var validationStatusErrors = testMapper.map(Set.of(apiError));
+        final var expectedError =
+                new ValidationStatusError("message", "$.field", "json-path", "ch:validation");
+
+        assertThat(validationStatusErrors,
+                is(arrayContaining(samePropertyValuesAs(expectedError))));
+    }
+
+    @Test
+    void mapFieldErrorListWhenNull() {
+        assertThat(testMapper.map((Set<ApiError>) null), is(nullValue()));
+    }
+}


### PR DESCRIPTION
We need a validation endpoint that the Software filer can use when they are using the Patch flow of submissions. Additionally, the same endpoint is used by the Transactions API to validate pre closing the transaction. 

Acceptance Criteria

Create a single endpoint that can be called by Transactions API and S/W filer. 

By doing so, this will help us to test the main acceptance criteria in the overall parent story around patching and validation rules.
GET /transactions/{transaction_id}/officers/{filing_resource_id}/validation_status

This will need to run all the validation that we have currently set up to run on the post endpoint.

Runs all validation for everything we’ve done for POST submissions already - call off to existing validation that is implemented. Will need to validate correct error messages are sent back.
<img width="805" alt="image" src="https://user-images.githubusercontent.com/118275754/217283235-aa30e898-c7aa-4057-ab6e-7be319c803fa.png">
