### PR TITLE
Dact 328 services unavailable

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +19,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
 import uk.gov.companieshouse.officerfiling.api.error.InvalidFilingException;
 import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.model.entity.Links;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +18,6 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
 import uk.gov.companieshouse.officerfiling.api.error.InvalidFilingException;
 import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
-import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.model.entity.Links;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/CompanyProfileServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/CompanyProfileServiceException.java
@@ -5,6 +5,10 @@ package uk.gov.companieshouse.officerfiling.api.exception;
  */
 public class CompanyProfileServiceException extends RuntimeException{
 
+    public CompanyProfileServiceException(final String message) {
+        super(message);
+    }
+
     public CompanyProfileServiceException(final String s, final Exception e) {
         super(s, e);
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/ServiceUnavailableException.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/ServiceUnavailableException.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.officerfiling.api.exception;
+
+public class ServiceUnavailableException extends RuntimeException {
+
+  public ServiceUnavailableException() {
+  }
+
+  public ServiceUnavailableException(final String message) {
+    super(message);
+  }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/ErrorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/ErrorMapper.java
@@ -11,7 +11,7 @@ import uk.gov.companieshouse.officerfiling.api.error.LocationType;
 @Mapper(componentModel = "spring", imports = {ErrorType.class, LocationType.class})
 public interface ErrorMapper {
     @Mapping(target = "error", source = "error")
-    @Mapping(target="type", expression = "java(ErrorType.VALIDATION.getType())")
+    @Mapping(target="type", expression = "java(apiError.getType())")
     @Mapping(target="location", expression = "java(\"$.\" + apiError.getLocation())")
     @Mapping(target="locationType", expression = "java(LocationType.JSON_PATH.getValue())")
     ValidationStatusError map(final ApiError apiError);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentService.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.officerfiling.api.service;
 
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 
 public interface CompanyAppointmentService {
     /**
@@ -12,9 +13,10 @@ public interface CompanyAppointmentService {
      * @param ericPassThroughHeader includes authorisation for company appointment fetch
      * @return the appointment if found
      * @throws CompanyAppointmentServiceException if Transaction not found or an error occurred
+     * @throws ServiceUnavailableException if Company Appointments API is unavailable
      */
     AppointmentFullRecordAPI getCompanyAppointment(String transactionId, String companyNumber, String appointmentId,
                                                    final String ericPassThroughHeader)
-            throws CompanyAppointmentServiceException;
+            throws CompanyAppointmentServiceException, ServiceUnavailableException;
 
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentServiceImpl.java
@@ -1,11 +1,16 @@
 package uk.gov.companieshouse.officerfiling.api.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
+import org.springframework.web.client.HttpServerErrorException.ServiceUnavailable;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 
 import java.io.IOException;
@@ -48,6 +53,9 @@ public class CompanyAppointmentServiceImpl implements CompanyAppointmentService{
                     .withCompanyName(companyAppointment.getName())
                     .build());
             return companyAppointment;
+        }
+        catch (final ApiErrorResponseException e) {
+            throw new ServiceUnavailableException();
         }
         catch (final URIValidationException | IOException e) {
             throw new CompanyAppointmentServiceException("Error Retrieving appointment " + appointmentId + " for company " + companyNumber, e);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentServiceImpl.java
@@ -1,20 +1,16 @@
 package uk.gov.companieshouse.officerfiling.api.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException.NotFound;
-import org.springframework.web.client.HttpServerErrorException.ServiceUnavailable;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
-import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Service
 public class CompanyAppointmentServiceImpl implements CompanyAppointmentService{
@@ -35,6 +31,7 @@ public class CompanyAppointmentServiceImpl implements CompanyAppointmentService{
      * @param ericPassThroughHeader includes authorisation for company appointment fetch
      * @return the appointment if found
      * @throws CompanyAppointmentServiceException if not found or an error occurred
+     * @throws ServiceUnavailableException if Company Appointments API is unavailable
      */
     @Override
     public AppointmentFullRecordAPI getCompanyAppointment(String transactionId, String companyNumber, String appointmentId,

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentServiceImpl.java
@@ -55,7 +55,7 @@ public class CompanyAppointmentServiceImpl implements CompanyAppointmentService{
             return companyAppointment;
         }
         catch (final ApiErrorResponseException e) {
-            throw new ServiceUnavailableException();
+            throw new ServiceUnavailableException("The service is down. Try again later");
         }
         catch (final URIValidationException | IOException e) {
             throw new CompanyAppointmentServiceException("Error Retrieving appointment " + appointmentId + " for company " + companyNumber, e);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileService.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.officerfiling.api.service;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 
 public interface CompanyProfileService {
 
@@ -14,8 +15,9 @@ public interface CompanyProfileService {
      * @param ericPassThroughHeader includes authorisation details
      * @return the company profile if found
      * @throws CompanyProfileServiceException if not found or an error occurred
+     * @throws ServiceUnavailableException if public API is unavailable
      */
     CompanyProfileApi getCompanyProfile(final String transactionId, final String companyNumber, final String ericPassThroughHeader)
-            throws CompanyAppointmentServiceException;
+            throws CompanyAppointmentServiceException, ServiceUnavailableException;
 
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileServiceImpl.java
@@ -1,15 +1,16 @@
 package uk.gov.companieshouse.officerfiling.api.service;
 
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Service
 public class CompanyProfileServiceImpl implements CompanyProfileService {
@@ -46,6 +47,9 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
                     .withCompanyName(companyProfile.getCompanyName())
                     .build());
             return companyProfile;
+        }
+        catch (final ApiErrorResponseException e) {
+            throw new ServiceUnavailableException();
         }
         catch (final URIValidationException | IOException e) {
             throw new CompanyProfileServiceException("Error Retrieving company profile " + companyNumber, e);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileServiceImpl.java
@@ -31,6 +31,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
      * @param ericPassThroughHeader includes authorisation details
      * @return the company profile if found
      * @throws CompanyProfileServiceException if not found or an error occurred
+     * @throws ServiceUnavailableException if public API is unavailable
      */
     @Override
     public CompanyProfileApi getCompanyProfile(final String transactionId, final String companyNumber, final String ericPassThroughHeader)

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyProfileServiceImpl.java
@@ -49,7 +49,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
             return companyProfile;
         }
         catch (final ApiErrorResponseException e) {
-            throw new ServiceUnavailableException();
+            throw new ServiceUnavailableException("The service is down. Try again later");
         }
         catch (final URIValidationException | IOException e) {
             throw new CompanyProfileServiceException("Error Retrieving company profile " + companyNumber, e);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
@@ -58,8 +58,8 @@ public class OfficerTerminationValidator {
      * @param passthroughHeader ERIC pass through header for authorisation
      * @return An object containing a list of any validation errors that have been raised
      */
-    public ApiErrors validate(HttpServletRequest request, OfficerFilingDto dto, Transaction transaction, String passthroughHeader)
-        throws ServiceUnavailableException {
+    public ApiErrors validate(HttpServletRequest request, OfficerFilingDto dto, Transaction transaction,
+        String passthroughHeader) {
             logger.debugContext(transaction.getId(), "Beginning officer termination validation", new LogHelper.Builder(transaction)
                 .withRequest(request)
                 .build());
@@ -90,12 +90,13 @@ public class OfficerTerminationValidator {
     }
 
     public Optional<AppointmentFullRecordAPI> getOfficerAppointment(HttpServletRequest request,
-        List<ApiError> errorList, OfficerFilingDto dto, Transaction transaction, String passthroughHeader)
-        throws ServiceUnavailableException {
+        List<ApiError> errorList, OfficerFilingDto dto, Transaction transaction, String passthroughHeader) {
         try {
             return Optional.ofNullable(
                     companyAppointmentService.getCompanyAppointment(transaction.getId(), transaction.getCompanyNumber(),
                             dto.getReferenceAppointmentId(), passthroughHeader));
+        } catch (ServiceUnavailableException e) {
+            createServiceError(request, errorList);
         } catch (CompanyAppointmentServiceException e) {
             createValidationError(request, errorList, "Officer not found. Please confirm the details and resubmit");
         }
@@ -103,11 +104,13 @@ public class OfficerTerminationValidator {
     }
 
     public Optional<CompanyProfileApi> getCompanyProfile(HttpServletRequest request,
-        List<ApiError> errorList, Transaction transaction, String passthroughHeader) throws ServiceUnavailableException {
+        List<ApiError> errorList, Transaction transaction, String passthroughHeader) {
         try {
             return Optional.ofNullable(
                 companyProfileService.getCompanyProfile(transaction.getId(), transaction.getCompanyNumber(),
                     passthroughHeader));
+        } catch (ServiceUnavailableException e) {
+            createServiceError(request, errorList);
         } catch (CompanyProfileServiceException e) {
             createValidationError(request, errorList, "Company not found. Please confirm the details and resubmit");
         }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
@@ -58,7 +58,8 @@ public class OfficerTerminationValidator {
      * @param passthroughHeader ERIC pass through header for authorisation
      * @return An object containing a list of any validation errors that have been raised
      */
-    public ApiErrors validate(HttpServletRequest request, OfficerFilingDto dto, Transaction transaction, String passthroughHeader) {
+    public ApiErrors validate(HttpServletRequest request, OfficerFilingDto dto, Transaction transaction, String passthroughHeader)
+        throws ServiceUnavailableException {
             logger.debugContext(transaction.getId(), "Beginning officer termination validation", new LogHelper.Builder(transaction)
                 .withRequest(request)
                 .build());
@@ -89,13 +90,12 @@ public class OfficerTerminationValidator {
     }
 
     public Optional<AppointmentFullRecordAPI> getOfficerAppointment(HttpServletRequest request,
-        List<ApiError> errorList, OfficerFilingDto dto, Transaction transaction, String passthroughHeader) {
+        List<ApiError> errorList, OfficerFilingDto dto, Transaction transaction, String passthroughHeader)
+        throws ServiceUnavailableException {
         try {
             return Optional.ofNullable(
                     companyAppointmentService.getCompanyAppointment(transaction.getId(), transaction.getCompanyNumber(),
                             dto.getReferenceAppointmentId(), passthroughHeader));
-        } catch (ServiceUnavailableException e) {
-            createServiceError(request, errorList);
         } catch (CompanyAppointmentServiceException e) {
             createValidationError(request, errorList, "Officer not found. Please confirm the details and resubmit");
         }
@@ -103,13 +103,11 @@ public class OfficerTerminationValidator {
     }
 
     public Optional<CompanyProfileApi> getCompanyProfile(HttpServletRequest request,
-        List<ApiError> errorList, Transaction transaction, String passthroughHeader) {
+        List<ApiError> errorList, Transaction transaction, String passthroughHeader) throws ServiceUnavailableException {
         try {
             return Optional.ofNullable(
                 companyProfileService.getCompanyProfile(transaction.getId(), transaction.getCompanyNumber(),
                     passthroughHeader));
-        } catch (ServiceUnavailableException e) {
-            createServiceError(request, errorList);
         } catch (CompanyProfileServiceException e) {
             createValidationError(request, errorList, "Company not found. Please confirm the details and resubmit");
         }
@@ -140,7 +138,7 @@ public class OfficerTerminationValidator {
     }
 
     /**
-     * Check to ensure an request isn't being filed for an officer who has already resigned.
+     * Check to ensure a request isn't being filed for an officer who has already resigned.
      * Used for Validation rules D19_9A/D19_9
      * @param request
      * @param errorList

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidator.java
@@ -10,6 +10,7 @@ import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
 import uk.gov.companieshouse.officerfiling.api.error.ErrorType;
 import uk.gov.companieshouse.officerfiling.api.error.LocationType;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
@@ -90,6 +91,9 @@ public class OfficerTerminationValidator {
             return Optional.ofNullable(
                     companyAppointmentService.getCompanyAppointment(transaction.getId(), transaction.getCompanyNumber(),
                             dto.getReferenceAppointmentId(), passthroughHeader));
+        } catch (ServiceUnavailableException e) {
+            errorList.add(new ApiError("The service is down. Try again later", request.getRequestURI(),
+                LocationType.JSON_PATH.getValue(), ErrorType.SERVICE.getType()));
         } catch (CompanyAppointmentServiceException e) {
             createValidationError(request, errorList, "Officer not found. Please confirm the details and resubmit");
         }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -37,6 +37,8 @@ import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerFilingMapper;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
@@ -353,6 +355,29 @@ class OfficerFilingControllerImplValidationIT {
             .andExpect(jsonPath("$.errors[0].location_type", is("json-path")))
             .andExpect(jsonPath("$.errors[0].error",
                 containsString("Officer not found. Please confirm the details and resubmit")));
+    }
+
+    @Test
+    void createFilingWhenProfileNotFoundThenResponse400() throws Exception {
+        when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
+        when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenThrow(
+            new CompanyProfileServiceException("Error Retrieving company"));
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER))
+            .thenReturn(companyAppointment);
+        final var body = "{"
+            + TM01_FRAGMENT
+            + "}";
+
+        mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
+                .contentType("application/json")
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.errors", hasSize(1)))
+            .andExpect(jsonPath("$.errors[0].type", is("ch:validation")))
+            .andExpect(jsonPath("$.errors[0].location_type", is("json-path")))
+            .andExpect(jsonPath("$.errors[0].error",
+                containsString("Company not found. Please confirm the details and resubmit")));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -38,7 +38,6 @@ import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
-import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerFilingMapper;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
@@ -53,6 +53,7 @@ class ValidationStatusControllerImplIT {
     private static final String DIRECTOR_NAME = "Director name";
     private static final String ETAG = "etag";
     private static final String COMPANY_TYPE = "ltd";
+    private static final String OFFICER_ROLE = "director";
     @MockBean
     private OfficerFilingService officerFilingService;
     @MockBean
@@ -101,6 +102,7 @@ class ValidationStatusControllerImplIT {
         companyAppointment.setName(DIRECTOR_NAME);
         companyAppointment.setAppointedOn(APPOINTMENT_DATE);
         companyAppointment.setEtag(ETAG);
+        companyAppointment.setOfficerRole(OFFICER_ROLE);
 
         when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClientMock);
         when(apiClientMock.transactions()).thenReturn(transactionResourceHandlerMock);

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplTest.java
@@ -40,6 +40,7 @@ class ValidationStatusControllerImplTest {
     private static final String ETAG = "etag";
     private static final String COMPANY_TYPE = "ltd";
     private static final String COMPANY_NUMBER = "COMPANY_NUMBER";
+    private static final String OFFICER_ROLE = "director";
     private static final String PASSTHROUGH_HEADER = "passthrough";
     @Mock
     private OfficerFilingService officerFilingService;
@@ -131,6 +132,7 @@ class ValidationStatusControllerImplTest {
         when(transaction.getId()).thenReturn(TRANS_ID);
         when(companyProfileService.getCompanyProfile(TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(companyProfile);
         when(companyAppointment.getEtag()).thenReturn(ETAG);
+        when(companyAppointment.getOfficerRole()).thenReturn(OFFICER_ROLE);
         when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
     }
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.officerfiling.api.validation;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +10,6 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
 import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
@@ -28,8 +26,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -102,16 +98,17 @@ class OfficerTerminationValidatorTest {
             .referenceAppointmentId(FILING_ID)
             .resignedOn(LocalDate.of(2022, 9, 13))
             .build();
-        List<ApiError> errorList = new ArrayList<>();
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(transaction.getId()).thenReturn(TRANS_ID);
         when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenThrow(
             new ServiceUnavailableException("The service is down. Try again later"));
 
-        final var exception = assertThrows(ServiceUnavailableException.class,
-            () -> officerTerminationValidator.getOfficerAppointment(request, errorList, dto, transaction, PASSTHROUGH_HEADER));
-        MatcherAssert.assertThat(exception.getMessage(),
-            is("The service is down. Try again later"));
+        final var apiErrors = officerTerminationValidator.validate(request, dto, transaction, PASSTHROUGH_HEADER);
+        assertThat(apiErrors.getErrors())
+            .as("An error should be produced when the Company Appointment Service is unavailable")
+            .hasSize(1)
+            .extracting(ApiError::getError)
+            .contains("The service is down. Try again later");
     }
 
     @Test
@@ -121,16 +118,17 @@ class OfficerTerminationValidatorTest {
             .referenceAppointmentId(FILING_ID)
             .resignedOn(LocalDate.of(2022, 9, 13))
             .build();
-        List<ApiError> errorList = new ArrayList<>();
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(transaction.getId()).thenReturn(TRANS_ID);
         when(companyProfileService.getCompanyProfile(transaction.getId(), COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenThrow(
             new ServiceUnavailableException("The service is down. Try again later"));
 
-        final var exception = assertThrows(ServiceUnavailableException.class,
-            () -> officerTerminationValidator.getCompanyProfile(request, errorList, transaction, PASSTHROUGH_HEADER));
-        MatcherAssert.assertThat(exception.getMessage(),
-            is("The service is down. Try again later"));
+        final var apiErrors = officerTerminationValidator.validate(request, dto, transaction, PASSTHROUGH_HEADER);
+        assertThat(apiErrors.getErrors())
+            .as("An error should be produced when the Company Profile Service is unavailable")
+            .hasSize(1)
+            .extracting(ApiError::getError)
+            .contains("The service is down. Try again later");
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.officerfiling.api.validation;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +11,7 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
 import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
@@ -26,6 +28,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.officerfiling.api.validation;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,7 +11,10 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentServiceImpl;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileServiceImpl;
@@ -24,6 +28,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,6 +96,44 @@ class OfficerTerminationValidatorTest {
     }
 
     @Test
+    void validationWhenCompanyAppointmentServiceUnavailable() {
+        final var dto = OfficerFilingDto.builder()
+            .referenceEtag("etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(LocalDate.of(2022, 9, 13))
+            .build();
+        List<ApiError> errorList = new ArrayList<>();
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenThrow(
+            new ServiceUnavailableException("The service is down. Try again later"));
+
+        final var exception = assertThrows(ServiceUnavailableException.class,
+            () -> officerTerminationValidator.getOfficerAppointment(request, errorList, dto, transaction, PASSTHROUGH_HEADER));
+        MatcherAssert.assertThat(exception.getMessage(),
+            is("The service is down. Try again later"));
+    }
+
+    @Test
+    void validationWhenCompanyProfileServiceUnavailable() {
+        final var dto = OfficerFilingDto.builder()
+            .referenceEtag("etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(LocalDate.of(2022, 9, 13))
+            .build();
+        List<ApiError> errorList = new ArrayList<>();
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyProfileService.getCompanyProfile(transaction.getId(), COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenThrow(
+            new ServiceUnavailableException("The service is down. Try again later"));
+
+        final var exception = assertThrows(ServiceUnavailableException.class,
+            () -> officerTerminationValidator.getCompanyProfile(request, errorList, transaction, PASSTHROUGH_HEADER));
+        MatcherAssert.assertThat(exception.getMessage(),
+            is("The service is down. Try again later"));
+    }
+
+    @Test
     void validationWhenOfficerNotIdentified() {
         final var dto = OfficerFilingDto.builder()
             .referenceEtag("etag")
@@ -110,6 +154,26 @@ class OfficerTerminationValidatorTest {
             .contains("Officer not found. Please confirm the details and resubmit");
     }
 
+    @Test
+    void validationWhenCompanyNotFound() {
+        final var dto = OfficerFilingDto.builder()
+            .referenceEtag("etag")
+            .referenceAppointmentId(FILING_ID)
+            .resignedOn(LocalDate.of(2022, 9, 13))
+            .build();
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(companyProfileService.getCompanyProfile(transaction.getId(), COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenThrow(
+            new CompanyProfileServiceException("Error Retrieving company"));
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER))
+            .thenReturn(companyAppointment);
+        final var apiErrors = officerTerminationValidator.validate(request, dto, transaction, PASSTHROUGH_HEADER);
+        assertThat(apiErrors.getErrors())
+            .as("An error should be produced when a Company cannot be found")
+            .hasSize(1)
+            .extracting(ApiError::getError)
+            .contains("Company not found. Please confirm the details and resubmit");
+    }
     @Test
     void validationWhenOfficerIdentifiedButFilingInvalid() {
         final var dto = OfficerFilingDto.builder()


### PR DESCRIPTION
Context: It was mentioned in a dev standup that we may need an error message if the company appointments api or public api is down Richard Walrond confirmed with Mike Moore and Joe Simons that an error message will be needed and we will need to block applications from progressing. There is a SLA of 99.9% uptime on API’s. 

As companies house
I want to stop software filers from filing a director removal request if the Company Appointments api or Public api is down
So that CHIPs is not overloaded with submissions to process that could potentially cause a data error.

https://companieshouse.atlassian.net/jira/software/c/projects/DACT/boards/477/backlog?view=detail&selectedIssue=DACT-328&issueLimit=100

<img width="902" alt="image" src="https://user-images.githubusercontent.com/118275754/218100585-3cb58703-b1f2-4cf2-9b23-c851b914adff.png">

Officer Filing VALIDATION TEST ONLY ADDED FOR THE CURRENT IMPLEMENTATION. Post validation to be removed in future ticket.

