### PR TITLE
DACT-336: Allow submission with pre 1992 appointment date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <!--- CH -->
         <structured-logging.version>1.9.14</structured-logging.version>
-        <private-api-sdk-java.version>2.0.207</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.223</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <api-security-java.version>0.3.10</api-security-java.version>
         <!--sonar configuration-->

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerTerminationValidatorTest.java
@@ -270,8 +270,24 @@ class OfficerTerminationValidatorTest {
     }
 
     @Test
-    void validateTerminationDateAfterAppointmentDateWhenValid() {
+    void validateTerminationDateAfterAppointmentDateWhenValidAndPost1992() {
+        when(companyAppointment.getIsPre1992Appointment()).thenReturn(false);
         when(companyAppointment.getAppointedOn()).thenReturn(LocalDate.of(2023, Month.JANUARY, 4));
+        final var officerFilingDto = OfficerFilingDto.builder()
+                .referenceEtag("etag")
+                .referenceAppointmentId(FILING_ID)
+                .resignedOn(LocalDate.of(2023, Month.JANUARY, 5))
+                .build();
+        officerTerminationValidator.validateTerminationDateAfterAppointmentDate(request, apiErrorsList, officerFilingDto, companyAppointment);
+        assertThat(apiErrorsList)
+                .as("An error should not be produced when resignation date is after appointment date")
+                .isEmpty();
+    }
+
+    @Test
+    void validateTerminationDateAfterAppointmentDateWhenValidAndPre1992() {
+        when(companyAppointment.getIsPre1992Appointment()).thenReturn(true);
+        when(companyAppointment.getAppointedBefore()).thenReturn(LocalDate.of(1990, Month.JANUARY, 4));
         final var officerFilingDto = OfficerFilingDto.builder()
                 .referenceEtag("etag")
                 .referenceAppointmentId(FILING_ID)


### PR DESCRIPTION
Context: If the appointed date is prior to 1992 we need to check the field appointed-before otherwise the API will be looking in the wrong place and the API will fall over.

If the appointment date is prior to 1992 then we need to use the Appointment-before field to get the appointment date.

If the appointment date is post/including 1992 onwards then we need to use the ‘appointment-on’ field to get the appointment date.

https://companieshouse.atlassian.net/browse/DACT-336