### PR TITLE
feat: update healthcheck route

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To create the officer filing an open transaction is required - see [Companies Ho
 ### Current Endpoints
 | Method | URI                                                                                         | Comments                                                             |
 |--------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
-| GET    | /officers/healthcheck                                                                       | System health check                                                  |
+| GET    | /officer-filing/healthcheck                                                                       | System health check                                                  |
 | POST   | /transactions/{transaction_id}/officers                                                     | Creates an officer filing resource, linking it to the transaction    |
 | GET    | /private/transactions/{transaction_id}/officers/<br/>{filing_resource_id}/filings           | Wraps the filing resource data to produce standard message for CHIPS |
 | GET    | /private/transactions/{transaction_id}/officers/<br/>{filing_resource_id}/validation_status | Final validation when the transaction is closed                      |

--- a/routes.yaml
+++ b/routes.yaml
@@ -2,7 +2,7 @@ app_name: officer-filing-api
 group: api    
 weight: 900
 routes:
-  1: ^/officers
+  1: ^/officer-filing/healthcheck
   2: ^/transactions/.*/officers
   3: ^/private/transactions/.*/officers
   4: ^/transactions/.*/officers/.*


### PR DESCRIPTION
This PR changes the healthcheck URL to avoid a clash with thunderbirds.
Goes with https://github.com/companieshouse/chs-configs/pull/2142