### PR TITLE
fix: health route

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -2,7 +2,7 @@ app_name: officer-filing-api
 group: api    
 weight: 900
 routes:
-  1: ^/officer-filing/healthcheck
+  1: ^/officer-filing
   2: ^/transactions/.*/officers
   3: ^/private/transactions/.*/officers
   4: ^/transactions/.*/officers/.*


### PR DESCRIPTION
This PR makes routes.yaml less specific about /officer-filing to allow all actuator endpoints to work