### PR TITLE
DACT-407-Include Filing Type name and description in the submission notification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <!--- CH -->
         <structured-logging.version>1.9.14</structured-logging.version>
-        <private-api-sdk-java.version>2.0.223</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.233</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <api-security-java.version>0.3.10</api-security-java.version>
         <!--sonar configuration-->

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/config/AppConfig.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/config/AppConfig.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.officerfiling.api.config;
 
 import java.time.Clock;
+import java.time.LocalDate;
+import java.util.function.Supplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -22,5 +24,10 @@ public class AppConfig {
     @Bean
     public Clock clock() {
         return Clock.systemUTC();
+    }
+
+    @Bean
+    public Supplier<LocalDate> dateNow() {
+        return LocalDate::now;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -115,11 +115,12 @@ public class FilingDataServiceImpl implements FilingDataService {
     private void setDescriptionFields(FilingApi filing, AppointmentFullRecordAPI companyAppointment) {
         String formattedTerminationDate = dateNowSupplier.get().format(formatter);
         filing.setDescriptionIdentifier(filingDescription);
-        filing.setDescription(filingDescription.replace("{director name}", companyAppointment.getOfficerName())
+        var officerFilingName = companyAppointment.getForename() + " " + companyAppointment.getSurname().toUpperCase();
+        filing.setDescription(filingDescription.replace("{director name}", officerFilingName)
             .replace("{termination date}", formattedTerminationDate));
         Map<String, String> values = new HashMap<>();
         values.put("termination date", formattedTerminationDate);
-        values.put("director name", companyAppointment.getOfficerName());
+        values.put("director name", officerFilingName);
         filing.setDescriptionValues(values);
     }
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
@@ -91,7 +91,8 @@ class FilingDataServiceImplTest {
 
         when(companyAppointment.getDateOfBirth()).thenReturn(dateOfBirthAPI);
         when(companyAppointment.getOfficerRole()).thenReturn("corporate-director");
-        when(companyAppointment.getOfficerName()).thenReturn(FULL_NAME);
+        when(companyAppointment.getForename()).thenReturn(FIRSTNAME);
+        when(companyAppointment.getSurname()).thenReturn(LASTNAME);
         when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(officerFiling));
         when(officerFilingMapper.mapFiling(officerFiling)).thenReturn(filingData);
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
@@ -110,7 +111,7 @@ class FilingDataServiceImplTest {
         assertThat(filingApi.getData(), is(equalTo(expectedMap)));
         assertThat(filingApi.getKind(), is("officer-filing#termination"));
         assertThat(filingApi.getDescription(), is("(TM01) Termination of appointment of director. Terminating appointment of "
-            + FULL_NAME + " on 16 March 2023"));
+            + FIRSTNAME + " " + LASTNAME.toUpperCase()  + " on 16 March 2023"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.model.delta.officers.SensitiveDateOfBirthAPI;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -37,10 +40,12 @@ class FilingDataServiceImplTest {
     private static final Instant RESIGNED_ON_INS = Instant.parse("2022-10-05T00:00:00Z");
     public static final String FIRSTNAME = "JOE";
     public static final String LASTNAME = "BLOGGS";
+    public static final String FULL_NAME = FIRSTNAME + " " + LASTNAME;
     public static final String DATE_OF_BIRTH_STR = "2000-10-20";
     private static final String PASSTHROUGH_HEADER = "passthrough";
     private static final String COMPANY_NUMBER = null;
     public static final Date3Tuple DATE_OF_BIRTH_TUPLE = new Date3Tuple(20, 10, 2000);
+    private static final LocalDate DUMMY_DATE = LocalDate.of(2023, 3, 16);
     @Mock
     private OfficerFilingService officerFilingService;
     @Mock
@@ -55,13 +60,17 @@ class FilingDataServiceImplTest {
     private Transaction transaction;
     @Mock
     private AppointmentFullRecordAPI companyAppointment;
+    @Mock
+    private Supplier<LocalDate> dateNowSupplier;
 
     private FilingDataServiceImpl testService;
 
     @BeforeEach
     void setUp() {
         testService = new FilingDataServiceImpl(officerFilingService, officerFilingMapper, logger, transactionService,
-                companyAppointmentService);
+                companyAppointmentService, dateNowSupplier);
+        ReflectionTestUtils.setField(testService, "filingDescription",
+            "(TM01) Termination of appointment of director. Terminating appointment of {director name} on {termination date}");
     }
 
     @Test
@@ -82,11 +91,13 @@ class FilingDataServiceImplTest {
 
         when(companyAppointment.getDateOfBirth()).thenReturn(dateOfBirthAPI);
         when(companyAppointment.getOfficerRole()).thenReturn("corporate-director");
+        when(companyAppointment.getOfficerName()).thenReturn(FULL_NAME);
         when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(officerFiling));
         when(officerFilingMapper.mapFiling(officerFiling)).thenReturn(filingData);
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
         when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, REF_APPOINTMENT_ID, PASSTHROUGH_HEADER ))
                 .thenReturn(companyAppointment);
+        when(dateNowSupplier.get()).thenReturn(DUMMY_DATE);
 
         final var filingApi = testService.generateOfficerFiling(TRANS_ID, FILING_ID, PASSTHROUGH_HEADER);
 
@@ -98,6 +109,8 @@ class FilingDataServiceImplTest {
 
         assertThat(filingApi.getData(), is(equalTo(expectedMap)));
         assertThat(filingApi.getKind(), is("officer-filing#termination"));
+        assertThat(filingApi.getDescription(), is("(TM01) Termination of appointment of director. Terminating appointment of "
+            + FULL_NAME + " on 16 March 2023"));
     }
 
     @Test


### PR DESCRIPTION
When a director removal submission is made by a software filer using our Officer Filing API or via Web service, then the expectation is that the user would receive an email confirmation to indicate that their director removal submission was received.

This email should include the company upon which the director removal submission was made against, the date the submission was received, the reference number (if the user needs to contact customer service) and the filing type description.
Filing description:

<img width="735" alt="image" src="https://user-images.githubusercontent.com/118275754/225949489-69933e94-05b9-4d57-836f-e7d1876fb313.png">

https://companieshouse.atlassian.net/browse/DACT-407