### PR TITLE
Dact 385 list of active directors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClient.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClient.java
@@ -15,7 +15,6 @@ import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException
 import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 
-
 @Component
 public class OracleQueryClient {
 
@@ -32,7 +31,6 @@ public class OracleQueryClient {
         this.logger = logger;
     }
 
-
     public List<ActiveOfficerDetails> getActiveOfficersDetails(String companyNumber) throws OfficerServiceException {
         var officersDetailsUrl = String.format("%s/company/%s/officers/active", oracleQueryApiUrl, companyNumber);
 
@@ -48,6 +46,4 @@ public class OracleQueryClient {
         }
         return Arrays.asList(response.getBody());
     }
-
-
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClient.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClient.java
@@ -18,7 +18,6 @@ import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 @Component
 public class OracleQueryClient {
 
-    private static final String CALLING_ORACLE_QUERY_API_URL_GET = "Calling Oracle Query API URL: %s";
     public static final String ORACLE_QUERY_API_STATUS_MESSAGE = "Oracle query api returned with status = %s, companyNumber = %s";
     @Value("${ORACLE_QUERY_API_URL}")
     private String oracleQueryApiUrl;
@@ -34,7 +33,7 @@ public class OracleQueryClient {
     public List<ActiveOfficerDetails> getActiveOfficersDetails(String companyNumber) throws OfficerServiceException {
         var officersDetailsUrl = String.format("%s/company/%s/officers/active", oracleQueryApiUrl, companyNumber);
 
-        logger.debugContext(companyNumber, String.format(CALLING_ORACLE_QUERY_API_URL_GET, officersDetailsUrl),
+        logger.debugContext(companyNumber, "Calling Oracle Query API URL",
             new LogHelper.Builder(companyNumber).build());
 
         ResponseEntity<ActiveOfficerDetails[]> response = restTemplate.getForEntity(officersDetailsUrl, ActiveOfficerDetails[].class);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClient.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClient.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.officerfiling.api.client;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
+
+
+@Component
+public class OracleQueryClient {
+
+    private static final String CALLING_ORACLE_QUERY_API_URL_GET = "Calling Oracle Query API URL: %s";
+    public static final String ORACLE_QUERY_API_STATUS_MESSAGE = "Oracle query api returned with status = %s, companyNumber = %s";
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${ORACLE_QUERY_API_URL:http://oracle-query-api:8080}")
+    private String oracleQueryApiUrl;
+
+    private final Logger logger;
+
+    public OracleQueryClient(Logger logger) {
+        this.logger = logger;
+    }
+
+
+    public List<ActiveOfficerDetails> getActiveOfficersDetails(String companyNumber) throws OfficerServiceException {
+        var officersDetailsUrl = String.format("%s/company/%s/officers/active", oracleQueryApiUrl, companyNumber);
+
+        logger.debugContext(companyNumber, String.format(CALLING_ORACLE_QUERY_API_URL_GET, officersDetailsUrl),
+            new LogHelper.Builder(companyNumber).build());
+
+        ResponseEntity<ActiveOfficerDetails[]> response = restTemplate.getForEntity(officersDetailsUrl, ActiveOfficerDetails[].class);
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new OfficerServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE, response.getStatusCode(), companyNumber));
+        }
+        if (response.getBody() == null) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(response.getBody());
+    }
+
+
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClient.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClient.java
@@ -22,14 +22,15 @@ public class OracleQueryClient {
     private static final String CALLING_ORACLE_QUERY_API_URL_GET = "Calling Oracle Query API URL: %s";
     public static final String ORACLE_QUERY_API_STATUS_MESSAGE = "Oracle query api returned with status = %s, companyNumber = %s";
     @Autowired
-    private RestTemplate restTemplate;
+    private final RestTemplate restTemplate;
 
-    @Value("${ORACLE_QUERY_API_URL:http://oracle-query-api:8080}")
+    @Value("${ORACLE_QUERY_API_URL}")
     private String oracleQueryApiUrl;
 
     private final Logger logger;
 
-    public OracleQueryClient(Logger logger) {
+    public OracleQueryClient(RestTemplate restTemplate, Logger logger) {
+        this.restTemplate = restTemplate;
         this.logger = logger;
     }
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/config/AppConfig.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/config/AppConfig.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.function.Supplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Main application configuration class.
@@ -29,5 +30,10 @@ public class AppConfig {
     @Bean
     public Supplier<LocalDate> dateNow() {
         return LocalDate::now;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/config/InterceptorConfig.java
@@ -20,6 +20,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
     private static final String TRANSACTIONS = "/transactions/**";
     private static final String PRIVATE = "/private/**";
+    private static final String PRIVATE_CLOSED = "/private/transactions/{transactionId}/officers/{filingResourceId}/filings";
     private static final String[] TRANSACTIONS_LIST = {TRANSACTIONS, PRIVATE};
 
     /**
@@ -70,7 +71,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
     private void addClosedTransactionInterceptor(InterceptorRegistry registry){
         registry.addInterceptor(closedTransactionInterceptor())
-                .addPathPatterns(PRIVATE);
+                .addPathPatterns(PRIVATE_CLOSED);
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/config/InterceptorConfig.java
@@ -20,7 +20,6 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
     private static final String TRANSACTIONS = "/transactions/**";
     private static final String PRIVATE = "/private/**";
-    private static final String PRIVATE_CLOSED = "/private/transactions/{transactionId}/officers/{filingResourceId}/filings";
     private static final String[] TRANSACTIONS_LIST = {TRANSACTIONS, PRIVATE};
 
     /**
@@ -71,7 +70,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
     private void addClosedTransactionInterceptor(InterceptorRegistry registry){
         registry.addInterceptor(closedTransactionInterceptor())
-                .addPathPatterns(PRIVATE_CLOSED);
+                .addPathPatterns(PRIVATE);
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerController.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static uk.gov.companieshouse.officerfiling.api.utils.Constants.ERIC_REQUEST_ID_KEY;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+
+public interface OfficerController {
+
+    /**
+     * Create an Officer Filing.
+     *
+     * @param transaction the Transaction
+     * @param transId        the Transaction ID
+     * @param reqId the request ID
+     * @throws NotImplementedException implementing classes must perform work
+     */
+    @GetMapping
+    default ResponseEntity<List<ActiveOfficerDetails>> getListActiveDirectorDetails(
+        @RequestAttribute("transaction") Transaction transaction,
+        @PathVariable("transactionId") String transId,
+        @RequestHeader(value = ERIC_REQUEST_ID_KEY) String reqId) {
+        throw new NotImplementedException();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
-import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
 import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
@@ -20,15 +19,13 @@ public interface OfficerController {
      * Create an Officer Filing.
      *
      * @param transaction the Transaction
-     * @param transId        the Transaction ID
-     * @param reqId the request ID
+     * @param request the servlet request
      * @throws NotImplementedException implementing classes must perform work
      */
     @GetMapping
-    default ResponseEntity<List<ActiveOfficerDetails>> getListActiveDirectorDetails(
+    default ResponseEntity<Object> getListActiveDirectorsDetails(
         @RequestAttribute("transaction") Transaction transaction,
-        @PathVariable("transactionId") String transId,
-        @RequestHeader(value = ERIC_REQUEST_ID_KEY) String reqId) {
+        HttpServletRequest request) {
         throw new NotImplementedException();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerController.java
@@ -1,17 +1,11 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
-import static uk.gov.companieshouse.officerfiling.api.utils.Constants.ERIC_REQUEST_ID_KEY;
-
-import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
-import org.springframework.web.bind.annotation.RequestHeader;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
-import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
 
 public interface OfficerController {
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
@@ -21,12 +22,14 @@ public class OfficerControllerImpl implements OfficerController {
     private final OfficerService officerService;
     private final Logger logger;
 
-    public OfficerControllerImpl(OfficerService officerService, final Logger logger) {
+    public OfficerControllerImpl(final OfficerService officerService, final Logger logger) {
         this.officerService = officerService;
         this.logger = logger;
     }
 
-    @GetMapping("/transactions/{transactionId}/officers/{filingResourceId}/active-officers-details")
+    @Override
+    @ResponseBody
+    @GetMapping(value = "/transactions/{transactionId}/officers/{filingResourceId}/active-officers-details", produces = {"application/json"})
     public ResponseEntity<Object> getListActiveDirectorsDetails(
             @RequestAttribute("transaction") Transaction transaction,
             final HttpServletRequest request) {
@@ -39,7 +42,9 @@ public class OfficerControllerImpl implements OfficerController {
                 .withRequest(request)
                 .build());
 
-            return ResponseEntity.status(HttpStatus.OK).body(officerService.getListActiveDirectorsDetails(request, transaction.getCompanyNumber()));
+            final var directorsDetails = officerService.getListActiveDirectorsDetails(request, transaction.getCompanyNumber());
+
+            return ResponseEntity.status(HttpStatus.OK).body(directorsDetails);
         } catch (OfficerServiceException e) {
             logger.debugContext(transaction.getId(), "Error retrieving active officers details", new Builder(transaction)
                 .withRequest(request)

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
@@ -29,7 +29,7 @@ public class OfficerControllerImpl implements OfficerController {
 
     @Override
     @ResponseBody
-    @GetMapping(value = "/transactions/{transactionId}/officers/active-officers-details", produces = {"application/json"})
+    @GetMapping(value = "/private/transactions/{transactionId}/officers/active-directors-details", produces = {"application/json"})
     public ResponseEntity<Object> getListActiveDirectorsDetails(
             @RequestAttribute("transaction") Transaction transaction,
             final HttpServletRequest request) {

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
@@ -29,7 +29,7 @@ public class OfficerControllerImpl implements OfficerController {
 
     @Override
     @ResponseBody
-    @GetMapping(value = "/private/transactions/{transactionId}/officers/active-directors-details", produces = {"application/json"})
+    @GetMapping(value = "/transactions/{transactionId}/officers/active-directors-details", produces = {"application/json"})
     public ResponseEntity<Object> getListActiveDirectorsDetails(
             @RequestAttribute("transaction") Transaction transaction,
             final HttpServletRequest request) {

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static uk.gov.companieshouse.officerfiling.api.utils.Constants.ERIC_REQUEST_ID_KEY;
+import static uk.gov.companieshouse.officerfiling.api.utils.Constants.TRANSACTION_ID_KEY;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
+
+@RestController
+public class OfficerControllerImpl implements OfficerController {
+
+    @Autowired
+    private OfficerService officerService;
+    private final Logger logger;
+
+    public OfficerControllerImpl(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @GetMapping("/transactions/{transactionId}/officers/{filingResourceId}/active-officers-details")
+    public ResponseEntity<List<ActiveOfficerDetails>> getListActiveDirectorDetails(
+            @RequestAttribute("transaction") Transaction transaction,
+            @PathVariable("transactionId") String transId,
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String reqId,
+            final HttpServletRequest request) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put(TRANSACTION_ID_KEY, transId);
+
+        try {
+            logger.debugContext(reqId, "Calling service to retrieve the active officers details."
+                , logMap);
+            return ResponseEntity.status(HttpStatus.OK).body(officerService.getListActiveDirectorDetails(request, transaction.getCompanyNumber()));
+        } catch (OfficerServiceException e) {
+            logger.errorContext(reqId, "Error retrieving active officers details.", e,
+                logMap);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
@@ -1,54 +1,49 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
-import static uk.gov.companieshouse.officerfiling.api.utils.Constants.ERIC_REQUEST_ID_KEY;
 import static uk.gov.companieshouse.officerfiling.api.utils.Constants.TRANSACTION_ID_KEY;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import javax.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
-import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
+import uk.gov.companieshouse.officerfiling.api.utils.LogHelper.Builder;
 
 @RestController
 public class OfficerControllerImpl implements OfficerController {
 
-    @Autowired
-    private OfficerService officerService;
+    private final OfficerService officerService;
     private final Logger logger;
 
-    public OfficerControllerImpl(final Logger logger) {
+    public OfficerControllerImpl(OfficerService officerService, final Logger logger) {
+        this.officerService = officerService;
         this.logger = logger;
     }
 
     @GetMapping("/transactions/{transactionId}/officers/{filingResourceId}/active-officers-details")
-    public ResponseEntity<List<ActiveOfficerDetails>> getListActiveDirectorDetails(
+    public ResponseEntity<Object> getListActiveDirectorsDetails(
             @RequestAttribute("transaction") Transaction transaction,
-            @PathVariable("transactionId") String transId,
-            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String reqId,
             final HttpServletRequest request) {
 
         var logMap = new HashMap<String, Object>();
-        logMap.put(TRANSACTION_ID_KEY, transId);
+        logMap.put(TRANSACTION_ID_KEY, transaction.getId());
 
         try {
-            logger.debugContext(reqId, "Calling service to retrieve the active officers details."
-                , logMap);
-            return ResponseEntity.status(HttpStatus.OK).body(officerService.getListActiveDirectorDetails(request, transaction.getCompanyNumber()));
+            logger.debugContext(transaction.getId(), "Calling service to retrieve the active officers details", new Builder(transaction)
+                .withRequest(request)
+                .build());
+
+            return ResponseEntity.status(HttpStatus.OK).body(officerService.getListActiveDirectorsDetails(request, transaction.getCompanyNumber()));
         } catch (OfficerServiceException e) {
-            logger.errorContext(reqId, "Error retrieving active officers details.", e,
-                logMap);
+            logger.debugContext(transaction.getId(), "Error retrieving active officers details", new Builder(transaction)
+                .withRequest(request)
+                .build());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImpl.java
@@ -29,7 +29,7 @@ public class OfficerControllerImpl implements OfficerController {
 
     @Override
     @ResponseBody
-    @GetMapping(value = "/transactions/{transactionId}/officers/{filingResourceId}/active-officers-details", produces = {"application/json"})
+    @GetMapping(value = "/transactions/{transactionId}/officers/active-officers-details", produces = {"application/json"})
     public ResponseEntity<Object> getListActiveDirectorsDetails(
             @RequestAttribute("transaction") Transaction transaction,
             final HttpServletRequest request) {

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/OfficerServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/OfficerServiceException.java
@@ -4,7 +4,4 @@ public class OfficerServiceException extends Exception {
     public OfficerServiceException(String message) {
         super(message);
     }
-    public OfficerServiceException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/OfficerServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/OfficerServiceException.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.officerfiling.api.exception;
+
+public class OfficerServiceException extends Exception {
+    public OfficerServiceException(String message) {
+        super(message);
+    }
+    public OfficerServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/ActiveOfficerDetails.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/ActiveOfficerDetails.java
@@ -1,0 +1,179 @@
+package uk.gov.companieshouse.officerfiling.api.model.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.StringUtils;
+import uk.gov.companieshouse.api.model.common.Address;
+import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerIdentificationTypeMapper;
+
+
+public class ActiveOfficerDetails {
+    @JsonProperty("fore_name_1")
+    private String foreName1;
+    @JsonProperty("fore_name_2")
+    private String foreName2;
+    private String surname;
+    private String occupation;
+    private String nationality;
+    @JsonProperty("date_of_birth")
+    private String dateOfBirth;
+    @JsonProperty("country_of_residence")
+    private String countryOfResidence;
+    @JsonProperty("date_of_appointment")
+    private String dateOfAppointment;
+    @JsonProperty("service_address")
+    private Address serviceAddress;
+    @JsonProperty("residential_address")
+    private Address residentialAddress;
+    @JsonProperty("is_corporate")
+    private boolean corporate;
+    private String role;
+    @JsonProperty("place_registered")
+    private String placeRegistered;
+    @JsonProperty("registration_number")
+    private String registrationNumber;
+    @JsonProperty("law_governed")
+    private String lawGoverned;
+    @JsonProperty("legal_form")
+    private String legalForm;
+    @JsonProperty("identification_type")
+    private String identificationType;
+
+    public String getForeName1() {
+        return foreName1;
+    }
+
+    public void setForeName1(String foreName1) {
+        this.foreName1 = foreName1;
+    }
+
+    public String getForeName2() {
+        return foreName2;
+    }
+
+    public void setForeName2(String foreName2) {
+        this.foreName2 = foreName2;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getOccupation() {
+        return occupation;
+    }
+
+    public void setOccupation(String occupation) {
+        this.occupation = occupation;
+    }
+
+    public String getNationality() {
+        return nationality;
+    }
+
+    public void setNationality(String nationality) {
+        this.nationality = nationality;
+    }
+
+    public String getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(String dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getCountryOfResidence() {
+        return countryOfResidence;
+    }
+
+    public void setCountryOfResidence(String countryOfResidence) {
+        this.countryOfResidence = countryOfResidence;
+    }
+
+    public Address getServiceAddress() {
+        return serviceAddress;
+    }
+
+    public void setServiceAddress(Address serviceAddress) {
+        this.serviceAddress = serviceAddress;
+    }
+
+    public Address getResidentialAddress() {
+        return residentialAddress;
+    }
+
+    public void setResidentialAddress(Address residentialAddress) {
+        this.residentialAddress = residentialAddress;
+    }
+
+    public String getDateOfAppointment() {
+        return dateOfAppointment;
+    }
+
+    public void setDateOfAppointment(String dateOfAppointment) {
+        this.dateOfAppointment = dateOfAppointment;
+    }
+
+    public boolean isCorporate() {
+        return corporate;
+    }
+
+    public void setCorporate(boolean corporate) {
+        this.corporate = corporate;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getPlaceRegistered() {
+        return placeRegistered;
+    }
+
+    public void setPlaceRegistered(String placeRegistered) {
+        this.placeRegistered = placeRegistered;
+    }
+
+    public String getRegistrationNumber() {
+        return registrationNumber;
+    }
+
+    public void setRegistrationNumber(String registrationNumber) {
+        this.registrationNumber = registrationNumber;
+    }
+
+    public String getLawGoverned() {
+        return lawGoverned;
+    }
+
+    public void setLawGoverned(String lawGoverned) {
+        this.lawGoverned = lawGoverned;
+    }
+
+    public String getLegalForm() {
+        return legalForm;
+    }
+
+    public void setLegalForm(String legalForm) {
+        this.legalForm = legalForm;
+    }
+
+    public String getIdentificationType() {
+        return identificationType;
+    }
+
+    public void setIdentificationType(String identificationType) {
+        if (StringUtils.isNotBlank(identificationType)) {
+            this.identificationType =
+                    OfficerIdentificationTypeMapper.mapIdentificationTypeToChs(identificationType);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/ActiveOfficerDetails.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/ActiveOfficerDetails.java
@@ -2,10 +2,11 @@ package uk.gov.companieshouse.officerfiling.api.model.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.data.mongodb.core.mapping.Document;
 import uk.gov.companieshouse.api.model.common.Address;
 import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerIdentificationTypeMapper;
 
-
+@Document(collection = "officer")
 public class ActiveOfficerDetails {
     @JsonProperty("fore_name_1")
     private String foreName1;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerIdentificationTypeMapper.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerIdentificationTypeMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.officerfiling.api.model.mapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class OfficerIdentificationTypeMapper {
+
+    private static Map<String, String> identificationTypesMap;
+    static {
+        identificationTypesMap = new HashMap<>();
+        identificationTypesMap.put("N", "non-eea");
+        identificationTypesMap.put("Y", "eea");
+        identificationTypesMap.put("U", "uk-limited-company");
+        identificationTypesMap.put("G", "other-corporate-body-or-firm");
+    }
+
+    private OfficerIdentificationTypeMapper(){}
+
+    public static String mapIdentificationTypeToChs(String oracleIdTypeCode) {
+        return identificationTypesMap.get(oracleIdTypeCode);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerService.java
@@ -2,17 +2,16 @@ package uk.gov.companieshouse.officerfiling.api.service;
 
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
-import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
 import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
 
 /**
- * Produces Filing Data format for consumption as JSON by filing-resource-handler external service.
+ * Produces a list of Directors from a specified company.
  */
 public interface OfficerService {
 
     /**
-     * Create FilingApi data from a retrieved Officer Filing resource.
+     * Retrieves list of active Directors
      *
      * @param companyNumber the company number
      * @param request the HTTP request
@@ -20,5 +19,5 @@ public interface OfficerService {
      *
      * @throws OfficerServiceException if Officers not found or an error occurred
      */
-    List<ActiveOfficerDetails> getListActiveDirectorDetails(HttpServletRequest request, String companyNumber) throws OfficerServiceException;
+    List<ActiveOfficerDetails> getListActiveDirectorsDetails(HttpServletRequest request, String companyNumber) throws OfficerServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerService.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.officerfiling.api.service;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+
+/**
+ * Produces Filing Data format for consumption as JSON by filing-resource-handler external service.
+ */
+public interface OfficerService {
+
+    /**
+     * Create FilingApi data from a retrieved Officer Filing resource.
+     *
+     * @param companyNumber the company number
+     * @param request the HTTP request
+     * @return the Officers if found
+     *
+     * @throws OfficerServiceException if Officers not found or an error occurred
+     */
+    List<ActiveOfficerDetails> getListActiveDirectorDetails(HttpServletRequest request, String companyNumber) throws OfficerServiceException;
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.officerfiling.api.service;
 import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.client.OracleQueryClient;
@@ -16,7 +15,6 @@ public class OfficerServiceImpl implements OfficerService {
     private final OracleQueryClient oracleQueryClient;
     private final Logger logger;
 
-    @Autowired
     public OfficerServiceImpl(OracleQueryClient oracleQueryClient,
         Logger logger) {
         this.oracleQueryClient = oracleQueryClient;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.officerfiling.api.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.officers.OfficersApi;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.client.OracleQueryClient;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+
+@Service
+public class OfficerServiceImpl implements OfficerService{
+
+    private final ApiClientService apiClientService;
+    private final OracleQueryClient oracleQueryClient;
+
+    private final Logger logger;
+
+    @Autowired
+    public OfficerServiceImpl(ApiClientService apiClientService, OracleQueryClient oracleQueryClient,
+        Logger logger) {
+        this.apiClientService = apiClientService;
+        this.oracleQueryClient = oracleQueryClient;
+        this.logger = logger;
+    }
+
+    public List<ActiveOfficerDetails> getListActiveDirectorDetails(HttpServletRequest request, String companyNumber) throws OfficerServiceException {
+        return createListOfActiveDirectors(request, oracleQueryClient.getActiveOfficersDetails(companyNumber));
+    }
+
+    private List<ActiveOfficerDetails> createListOfActiveDirectors(HttpServletRequest request, List<ActiveOfficerDetails> officersDetails) {
+        var directorDetails = new ArrayList<ActiveOfficerDetails>();
+
+        for (ActiveOfficerDetails officer : officersDetails) {
+            if (officer != null) {
+                if (officer.getRole() != null) {
+                    if (officer.getRole().equals("Director")) {
+                        directorDetails.add(officer);
+                    }
+                }
+                else {
+                    logger.errorRequest(request, "null data was found in the oracle-query-api data within the Role field");
+                }
+            }
+            else {
+                logger.errorRequest(request, "null data was found in the oracle-query-api data, the officer was null");
+            }
+        }
+        return directorDetails;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -4,34 +4,26 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
-import uk.gov.companieshouse.api.handler.exception.URIValidationException;
-import uk.gov.companieshouse.api.model.officers.OfficersApi;
-import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.client.OracleQueryClient;
 import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
 import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
 
 @Service
-public class OfficerServiceImpl implements OfficerService{
+public class OfficerServiceImpl implements OfficerService {
 
-    private final ApiClientService apiClientService;
     private final OracleQueryClient oracleQueryClient;
-
     private final Logger logger;
 
     @Autowired
-    public OfficerServiceImpl(ApiClientService apiClientService, OracleQueryClient oracleQueryClient,
+    public OfficerServiceImpl(OracleQueryClient oracleQueryClient,
         Logger logger) {
-        this.apiClientService = apiClientService;
         this.oracleQueryClient = oracleQueryClient;
         this.logger = logger;
     }
 
-    public List<ActiveOfficerDetails> getListActiveDirectorDetails(HttpServletRequest request, String companyNumber) throws OfficerServiceException {
+    public List<ActiveOfficerDetails> getListActiveDirectorsDetails(HttpServletRequest request, String companyNumber) throws OfficerServiceException {
         return createListOfActiveDirectors(request, oracleQueryClient.getActiveOfficersDetails(companyNumber));
     }
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClientTest.java
@@ -56,6 +56,20 @@ class OracleQueryClientTest {
     }
 
     @Test
+    void listOfActiveOfficersDetailsReturnedFromOracleIsNull() throws OfficerServiceException {
+        var officer1 = new ActiveOfficerDetails();
+        var officer2 = new ActiveOfficerDetails();
+        ActiveOfficerDetails[] officerArray = {};
+
+        when(restTemplate.getForEntity(CLIENT_URL + "/company/" + COMPANY_NUMBER + ACTIVE_OFFICERS_PATH, ActiveOfficerDetails[].class))
+            .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        var result = testClient.getActiveOfficersDetails(COMPANY_NUMBER);
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+
+    @Test
     void exceptionIsThrownWhenListOfActiveDirectorsIsNotFound() {
         when(restTemplate.getForEntity(CLIENT_URL + "/company/" + COMPANY_NUMBER + ACTIVE_OFFICERS_PATH, ActiveOfficerDetails[].class))
                 .thenReturn(new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE));

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/client/OracleQueryClientTest.java
@@ -1,0 +1,67 @@
+package uk.gov.companieshouse.officerfiling.api.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+
+@ExtendWith(MockitoExtension.class)
+class OracleQueryClientTest {
+
+    private static final String ACTIVE_OFFICERS_PATH = "/officers/active";
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String CLIENT_URL = "http://oracle-query-api";
+
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private Logger logger;
+    private OracleQueryClient testClient;
+
+
+
+    @BeforeEach
+    void setup() {
+        testClient = new OracleQueryClient(restTemplate, logger);
+        ReflectionTestUtils.setField(testClient, "oracleQueryApiUrl", CLIENT_URL);
+    }
+
+
+    @Test
+    void listOfActiveOfficersDetailsReturnedFromOracleWhenFound() throws OfficerServiceException {
+        var officer1 = new ActiveOfficerDetails();
+        var officer2 = new ActiveOfficerDetails();
+        ActiveOfficerDetails[] officerArray = {officer1, officer2};
+
+        when(restTemplate.getForEntity(CLIENT_URL + "/company/" + COMPANY_NUMBER + ACTIVE_OFFICERS_PATH, ActiveOfficerDetails[].class))
+                .thenReturn(new ResponseEntity<>(officerArray, HttpStatus.OK));
+
+        var result = testClient.getActiveOfficersDetails(COMPANY_NUMBER);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void exceptionIsThrownWhenListOfActiveDirectorsIsNotFound() {
+        when(restTemplate.getForEntity(CLIENT_URL + "/company/" + COMPANY_NUMBER + ACTIVE_OFFICERS_PATH, ActiveOfficerDetails[].class))
+                .thenReturn(new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE));
+
+        var serviceException = assertThrows(OfficerServiceException.class, () -> testClient.getActiveOfficersDetails(COMPANY_NUMBER));
+        assertTrue(serviceException.getMessage().contains(COMPANY_NUMBER));
+        assertTrue(serviceException.getMessage().contains(HttpStatus.SERVICE_UNAVAILABLE.toString()));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplIT.java
@@ -90,7 +90,7 @@ class OfficerControllerImplIT {
 
         when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenReturn(officers);
 
-        mockMvc.perform(get("/transactions/{transactionId}/officers/{filingResourceId}/active-officers-details", TRANS_ID, FILING_ID)
+        mockMvc.perform(get("/transactions/{transactionId}/officers/active-officers-details", TRANS_ID, FILING_ID)
             .headers(httpHeaders).requestAttr("transaction", transaction))
             .andDo(print())
             .andExpect(status().isOk())
@@ -102,7 +102,7 @@ class OfficerControllerImplIT {
 
         when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenThrow(new OfficerServiceException("Error retrieving Officers"));
 
-        mockMvc.perform(get("/transactions/{transactionId}/officers/{filingResourceId}/active-officers-details", TRANS_ID, FILING_ID)
+        mockMvc.perform(get("/transactions/{transactionId}/officers/active-officers-details", TRANS_ID, FILING_ID)
                 .headers(httpHeaders).requestAttr("transaction", transaction))
             .andDo(print())
             .andExpect(status().isInternalServerError());

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplIT.java
@@ -1,0 +1,153 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.api.interceptor.OpenTransactionInterceptor;
+import uk.gov.companieshouse.api.interceptor.TransactionInterceptor;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.client.OracleQueryClient;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerIdentificationTypeMapper;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
+import uk.gov.companieshouse.officerfiling.api.service.TransactionService;
+import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
+
+@Tag("web")
+@WebMvcTest(controllers = OfficerControllerImpl.class)
+class OfficerControllerImplIT {
+    private static final String TRANS_ID = "4f56fdf78b357bfc";
+    private static final String FILING_ID = "632c8e65105b1b4a9f0d1f5e";
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String USER ="user";
+    private static final String KEY ="key";
+    private static final String KEY_ROLE ="*";
+    @MockBean
+    private OfficerFilingService officerFilingService;
+    @MockBean
+    private TransactionService transactionService;
+    @MockBean
+    private LogHelper logHelper;
+    @MockBean
+    private Logger logger;
+    @MockBean
+    private ApiClientService apiClientService;
+    @MockBean
+    private OfficerIdentificationTypeMapper identificationTypeMapper;
+    @MockBean
+    private TransactionInterceptor transactionInterceptor;
+    @MockBean
+    private OpenTransactionInterceptor openTransactionInterceptor;
+    @MockBean
+    private OfficerService officerService;
+    @MockBean
+    private OracleQueryClient oracleQueryClient;
+    @MockBean
+    private RestTemplate restTemplate;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private Transaction transaction;
+    private HttpHeaders httpHeaders;
+    @Autowired
+    private OfficerControllerImpl testController;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        httpHeaders = new HttpHeaders();
+        httpHeaders.add("ERIC-Access-Token", PASSTHROUGH_HEADER);
+        httpHeaders.add("ERIC-Identity", USER);
+        httpHeaders.add("ERIC-Identity-Type", KEY);
+        httpHeaders.add("ERIC-Authorised-Key-Roles", KEY_ROLE);
+        httpHeaders.add("ERIC-Authorised-Token-Permissions", "company_officers=readprotected,delete");
+        when(transactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        when(openTransactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(transaction.getStatus()).thenReturn(TransactionStatus.OPEN);
+    }
+
+    @Test
+    void getListOfActiveDirectorsDetailsDetailsWhenFound() throws Exception {
+        final var officer = new ActiveOfficerDetails();
+        officer.setForeName1("John");
+        officer.setSurname("DOE");
+
+        final var officers = Arrays.asList(officer, officer);
+        when(officerService.getListActiveDirectorsDetails(request, transaction.getCompanyNumber())).thenReturn(officers);
+        //when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenReturn(officers);
+
+        mockMvc.perform(get("/transactions/{transactionId}/officers/{filingResourceId}/active-officers-details", TRANS_ID, FILING_ID)
+            .headers(httpHeaders).requestAttr("transaction", transaction))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)))
+            .andExpect(jsonPath("$[0].data", is(officers)))
+            .andExpect(jsonPath("$[0].kind", is("officer-filing#termination")));
+    }
+
+//    @Test
+//    void getListOfActiveDirectorsDetailsDetailsWhenNotFound() throws Exception {
+//        when(filingDataService.generateOfficerFiling(TRANS_ID, FILING_ID, PASSTHROUGH_HEADER)).thenThrow(new ResourceNotFoundException("for Not Found scenario"));
+//        Transaction transaction = new Transaction();
+//        transaction.setStatus(TransactionStatus.CLOSED);
+//
+//        mockMvc.perform(
+//                        get("/private/transactions/{id}/officers/{filingId}/filings", TRANS_ID,
+//                                FILING_ID).headers(httpHeaders)
+//                                .requestAttr("transaction", transaction))
+//                .andDo(print())
+//                .andExpect(status().isNotFound())
+//                .andExpect(status().reason(is("Resource not found")))
+//                .andExpect(jsonPath("$").doesNotExist());
+//    }
+//
+//    @Test
+//    void getFilingsTransactionOpen() throws Exception {
+//        Transaction transaction = new Transaction();
+//        transaction.setStatus(TransactionStatus.OPEN);
+//
+//        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/filings", TRANS_ID, FILING_ID)
+//                        .headers(httpHeaders).requestAttr("transaction", transaction))
+//                .andDo(print())
+//                .andExpect(status().isInternalServerError());
+//    }
+//
+//    @Test
+//    void getFilingsNonKey() throws Exception {
+//        Transaction transaction = new Transaction();
+//        transaction.setStatus(TransactionStatus.CLOSED);
+//        httpHeaders.set("ERIC-Identity-Type", "oauth2");
+//
+//        mockMvc.perform(get("/private/transactions/{id}/officers/{filingId}/filings", TRANS_ID, FILING_ID)
+//                        .headers(httpHeaders).requestAttr("transaction", transaction))
+//                .andDo(print())
+//                .andExpect(status().isForbidden());
+//    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplIT.java
@@ -80,7 +80,7 @@ class OfficerControllerImplIT {
     }
 
     @Test
-    void getListOfActiveDirectorsDetailsDetailsWhenFoundTthen200() throws Exception {
+    void getListOfActiveDirectorsDetailsWhenFoundThen200() throws Exception {
         var officer = new ActiveOfficerDetails();
         officer.setForeName1("John");
         officer.setSurname("DOE");
@@ -90,7 +90,7 @@ class OfficerControllerImplIT {
 
         when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenReturn(officers);
 
-        mockMvc.perform(get("/transactions/{transactionId}/officers/active-officers-details", TRANS_ID, FILING_ID)
+        mockMvc.perform(get("/private/transactions/{transactionId}/officers/active-directors-details", TRANS_ID)
             .headers(httpHeaders).requestAttr("transaction", transaction))
             .andDo(print())
             .andExpect(status().isOk())
@@ -102,7 +102,7 @@ class OfficerControllerImplIT {
 
         when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenThrow(new OfficerServiceException("Error retrieving Officers"));
 
-        mockMvc.perform(get("/transactions/{transactionId}/officers/active-officers-details", TRANS_ID, FILING_ID)
+        mockMvc.perform(get("/private/transactions/{transactionId}/officers/active-directors-details", TRANS_ID)
                 .headers(httpHeaders).requestAttr("transaction", transaction))
             .andDo(print())
             .andExpect(status().isInternalServerError());

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplIT.java
@@ -90,7 +90,7 @@ class OfficerControllerImplIT {
 
         when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenReturn(officers);
 
-        mockMvc.perform(get("/private/transactions/{transactionId}/officers/active-directors-details", TRANS_ID)
+        mockMvc.perform(get("/transactions/{transactionId}/officers/active-directors-details", TRANS_ID)
             .headers(httpHeaders).requestAttr("transaction", transaction))
             .andDo(print())
             .andExpect(status().isOk())
@@ -102,7 +102,7 @@ class OfficerControllerImplIT {
 
         when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenThrow(new OfficerServiceException("Error retrieving Officers"));
 
-        mockMvc.perform(get("/private/transactions/{transactionId}/officers/active-directors-details", TRANS_ID)
+        mockMvc.perform(get("/transactions/{transactionId}/officers/active-directors-details", TRANS_ID)
                 .headers(httpHeaders).requestAttr("transaction", transaction))
             .andDo(print())
             .andExpect(status().isInternalServerError());

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplTest.java
@@ -20,7 +20,7 @@ import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
 @ExtendWith(MockitoExtension.class)
 class OfficerControllerImplTest {
 
-    public static final String TRANS_ID = "117524-754816-491724";
+    private static final String TRANS_ID = "117524-754816-491724";
     @Mock
     private Logger logger;
     @Mock

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerImplTest.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
+
+@ExtendWith(MockitoExtension.class)
+class OfficerControllerImplTest {
+
+    public static final String TRANS_ID = "117524-754816-491724";
+    @Mock
+    private Logger logger;
+    @Mock
+    private Transaction transaction;
+    @Mock
+    private OfficerService officerService;
+    @Mock
+    private HttpServletRequest request;
+    private OfficerController testService;
+
+    @BeforeEach
+    void setUp() {
+        testService = new OfficerControllerImpl(officerService, logger);
+        transaction.setId(TRANS_ID);
+    }
+
+    @Test
+    void getListOfActiveDirectorsDetailsDetails() throws OfficerServiceException {
+        var officers = Arrays.asList(new ActiveOfficerDetails(), new ActiveOfficerDetails());
+        when(officerService.getListActiveDirectorsDetails(request, transaction.getCompanyNumber())).thenReturn(officers);
+        var response = testService.getListActiveDirectorsDetails(transaction, request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void getListOfActiveDirectorsDetailsDetailsThrowsExceptionWhenNotFound() throws OfficerServiceException {
+        when(officerService.getListActiveDirectorsDetails(request, transaction.getCompanyNumber())).thenThrow(OfficerServiceException.class);
+        var response = testService.getListActiveDirectorsDetails(transaction, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerControllerTest.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
+
+class OfficerControllerTest {
+
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private Transaction transaction;
+
+
+    @Test
+    void getListActiveDirectorsDetails() {
+
+        var testController = new OfficerController(){};
+
+        assertThrows(NotImplementedException.class,
+            () -> testController.getListActiveDirectorsDetails(transaction, request));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerIdentificationTypeMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerIdentificationTypeMapperTest.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.officerfiling.api.model.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OfficerIdentificationTypeMapperTest {
+
+    @Test
+    void testNonEEAMapping() {
+        String chsType = OfficerIdentificationTypeMapper.mapIdentificationTypeToChs("N");
+        assertEquals("non-eea", chsType);
+    }
+
+    @Test
+    void testEEAMapping() {
+        String chsType = OfficerIdentificationTypeMapper.mapIdentificationTypeToChs("Y");
+        assertEquals("eea", chsType);
+    }
+
+    @Test
+    void testUKLimitedCompanyMapping() {
+        String chsType = OfficerIdentificationTypeMapper.mapIdentificationTypeToChs("U");
+        assertEquals("uk-limited-company", chsType);
+    }
+
+    @Test
+    void testOtherCorporateBodyOrFirmMapping() {
+        String chsType = OfficerIdentificationTypeMapper.mapIdentificationTypeToChs("G");
+        assertEquals("other-corporate-body-or-firm", chsType);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Z", " ", ""})
+    void testNullUnrecognizedMappings(String type) {
+        String chsType = OfficerIdentificationTypeMapper.mapIdentificationTypeToChs(type);
+        assertNull(chsType);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImplTest.java
@@ -1,0 +1,90 @@
+package uk.gov.companieshouse.officerfiling.api.service;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.handler.officers.OfficersResourceHandler;
+import uk.gov.companieshouse.api.handler.officers.request.OfficersList;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.officers.OfficersApi;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.client.OracleQueryClient;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.model.entity.ActiveOfficerDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OfficerServiceImplTest {
+
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String SUBMISSION_ID = "ABCDEFG";
+    @MockBean
+    private HttpServletRequest request;
+    @MockBean
+    private Logger logger;
+
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private InternalApiClient apiClient;
+
+    @Mock
+    private OracleQueryClient oracleQueryClient;
+
+    @Mock
+    private OfficersResourceHandler officersResourceHandler;
+
+    @Mock
+    private OfficersList officersList;
+
+    @Mock
+    private ApiResponse<OfficersApi> apiResponse;
+    private OfficerService testService;
+
+    @BeforeEach
+    void setUp() {
+        testService = new OfficerServiceImpl(oracleQueryClient, logger);
+    }
+
+    @Test
+    void getListOfActiveDirectorsDetailsWhenFound() throws OfficerServiceException {
+        List<ActiveOfficerDetails> officers = testListOfOfficers();
+        List<ActiveOfficerDetails> Directors = officers.subList(0, 2);
+        when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenReturn(officers);
+
+        var response = testService.getListActiveDirectorsDetails(request, COMPANY_NUMBER);
+        assertThat(response).hasSize(2);
+        assertThat(response).isEqualTo(Directors);
+    }
+
+    @Test
+    void exceptionIsThrownWhenOfficersDetailsNotFound() throws OfficerServiceException {
+        when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenThrow(OfficerServiceException.class);
+
+        final var exception = assertThrows(OfficerServiceException.class,
+            () -> testService.getListActiveDirectorsDetails(request, COMPANY_NUMBER));
+    }
+
+    private List<ActiveOfficerDetails> testListOfOfficers() {
+        ActiveOfficerDetails officer1 = new ActiveOfficerDetails();
+        ActiveOfficerDetails officer2 = new ActiveOfficerDetails();
+        ActiveOfficerDetails officer3 = new ActiveOfficerDetails();
+        officer1.setRole("Director");
+        officer2.setRole("Director");
+        officer3.setRole("Secretary");
+        List<ActiveOfficerDetails> officers = Arrays.asList(officer1, officer2, officer3);
+        return officers;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImplTest.java
@@ -65,8 +65,7 @@ class OfficerServiceImplTest {
         when(oracleQueryClient.getActiveOfficersDetails(COMPANY_NUMBER)).thenReturn(officers);
 
         var response = testService.getListActiveDirectorsDetails(request, COMPANY_NUMBER);
-        assertThat(response).hasSize(2);
-        assertThat(response).isEqualTo(Directors);
+        assertThat(response).hasSize(2).isEqualTo(Directors);
     }
 
     @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,3 +3,5 @@ spring.jackson.property-naming-strategy=SNAKE_CASE
 
 
 logging.level.uk.gov.companieshouse.officerfiling.api=DEBUG
+
+ORACLE_QUERY_API_URL=http://oracle-query-api


### PR DESCRIPTION
The current directors page is the 6th page in the happy path journey for the web service. It acts as a page where an Officer may select from a list of active directors associated with a company to remove. 

An Officer should be able to click the remove director link which will take them to the ‘When was this director removed ?’ (removal date) page.

To complete this work, we first need an endpoint to retrieve the list of active Directors.

<img width="728" alt="image" src="https://user-images.githubusercontent.com/118275754/228831095-4c70ee69-124d-4129-9800-93b6aca505d5.png">