### PR TITLE
DACT-282: removing the temporary logging.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -113,20 +113,15 @@ public class FilingDataServiceImpl implements FilingDataService {
     }
 
     private void setDescriptionFields(FilingApi filing, AppointmentFullRecordAPI companyAppointment) {
-        logger.debug("RJW - Inside setDescriptionFields" );
         String formattedTerminationDate = dateNowSupplier.get().format(formatter);
         filing.setDescriptionIdentifier(filingDescription);
         var officerFilingName = companyAppointment.getForename() + " " + companyAppointment.getSurname().toUpperCase();
-        logger.debug("RJW - officerFilingName = " + officerFilingName );
         filing.setDescription(filingDescription.replace("{director name}", officerFilingName)
             .replace("{termination date}", formattedTerminationDate));
         Map<String, String> values = new HashMap<>();
         values.put("termination date", formattedTerminationDate);
         values.put("director name", officerFilingName);
         filing.setDescriptionValues(values);
-        logger.debug("RJW - filing.getDescription = " + filing.getDescription() );
-        logger.debug("RJW - filing.getDescriptionIdentifier = " + filing.getDescriptionIdentifier() );
-        logger.debug("RJW - filing.getDescriptionValues = " + filing.getDescriptionValues());
     }
 
 }


### PR DESCRIPTION
Taking out the temporary logging that we added as it should no longer be needed as the issue was that the versions were not upping in the pipeline, so we had older code in staging to reserve2, which was why the description was missing.