### PR TITLE
Dact 385 retrieve list of directors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsController.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
+
+public interface DirectorsController {
+
+    /**
+     * Create an Officer Filing.
+     *
+     * @param transaction the Transaction
+     * @param request the servlet request
+     * @throws NotImplementedException implementing classes must perform work
+     */
+    @GetMapping
+    default ResponseEntity<Object> getListActiveDirectorsDetails(
+        @RequestAttribute("transaction") Transaction transaction,
+        HttpServletRequest request) {
+        throw new NotImplementedException();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsController.java
@@ -10,7 +10,7 @@ import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException
 public interface DirectorsController {
 
     /**
-     * Create an Officer Filing.
+     * Retrieve list of directors.
      *
      * @param transaction the Transaction
      * @param request the servlet request

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImpl.java
@@ -1,0 +1,60 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static uk.gov.companieshouse.officerfiling.api.utils.Constants.TRANSACTION_ID_KEY;
+
+import java.util.HashMap;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
+import uk.gov.companieshouse.officerfiling.api.utils.LogHelper.Builder;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+@RestController
+public class DirectorsControllerImpl implements DirectorsController {
+
+    private final OfficerService officerService;
+    private final Logger logger;
+
+    public DirectorsControllerImpl(final OfficerService officerService, final Logger logger) {
+        this.officerService = officerService;
+        this.logger = logger;
+    }
+
+    @Override
+    @ResponseBody
+    @GetMapping(value = "/transactions/{transactionId}/officers/active-directors-details", produces = {"application/json"})
+    public ResponseEntity<Object> getListActiveDirectorsDetails(
+        @RequestAttribute("transaction") Transaction transaction,
+        final HttpServletRequest request) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put(TRANSACTION_ID_KEY, transaction.getId());
+
+        try {
+            logger.debugContext(transaction.getId(), "Calling service to retrieve the active officers details", new Builder(transaction)
+                .withRequest(request)
+                .build());
+
+            final var passthroughHeader =
+                request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+
+            final var directorsDetails = officerService.getListOfActiveDirectorsDetails(request, transaction.getId(),
+                transaction.getCompanyNumber(), passthroughHeader);
+
+            return ResponseEntity.status(HttpStatus.OK).body(directorsDetails);
+        } catch (OfficerServiceException e) {
+            logger.debugContext(transaction.getId(), "Error retrieving active officers details", new Builder(transaction)
+                .withRequest(request)
+                .build());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/OfficerServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/exception/OfficerServiceException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.officerfiling.api.exception;
+
+/**
+ * Company profile not found or external query failed.
+ */
+public class OfficerServiceException extends RuntimeException{
+
+    public OfficerServiceException(final String message) {
+        super(message);
+    }
+
+    public OfficerServiceException(final String s, final Exception e) {
+        super(s, e);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerService.java
@@ -6,17 +6,19 @@ import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
 import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
 import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 
+/**
+ * Produces a list of Directors from a specified company.
+ */
 public interface OfficerService {
 
     /**
-     * Query the officers service for a given company.
+     * Retrieves list of active Directors
      *
-     * @param transactionId the ID of the related transaction
-     * @param companyNumber the Company Number
-     * @param ericPassThroughHeader includes authorisation details
-     * @return the company profile if found
-     * @throws OfficerServiceException if not found or an error occurred
-     * @throws ServiceUnavailableException if public API is unavailable
+     * @param companyNumber the company number
+     * @param request the HTTP request
+     * @return the Officers if found
+     *
+     * @throws OfficerServiceException if Officers not found or an error occurred
      */
     List<CompanyOfficerApi> getListOfActiveDirectorsDetails(final HttpServletRequest request, final String transactionId,
         final String companyNumber, final String ericPassThroughHeader)

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerService.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.officerfiling.api.service;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
+
+public interface OfficerService {
+
+    /**
+     * Query the officers service for a given company.
+     *
+     * @param transactionId the ID of the related transaction
+     * @param companyNumber the Company Number
+     * @param ericPassThroughHeader includes authorisation details
+     * @return the company profile if found
+     * @throws OfficerServiceException if not found or an error occurred
+     * @throws ServiceUnavailableException if public API is unavailable
+     */
+    List<CompanyOfficerApi> getListOfActiveDirectorsDetails(final HttpServletRequest request, final String transactionId,
+        final String companyNumber, final String ericPassThroughHeader)
+            throws OfficerServiceException, ServiceUnavailableException;
+
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -1,0 +1,89 @@
+package uk.gov.companieshouse.officerfiling.api.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
+import uk.gov.companieshouse.api.model.officers.OfficersApi;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
+
+@Service
+public class OfficerServiceImpl implements OfficerService {
+
+    private static final List<String> ALLOWED_OFFICER_ROLES = List.of("director", "corporate-director", "nominee-director", "corporate-nominee-director");
+    private final ApiClientService apiClientService;
+    private final Logger logger;
+
+    public OfficerServiceImpl(ApiClientService apiClientService, Logger logger) {
+        this.apiClientService = apiClientService;
+        this.logger = logger;
+    }
+
+    /**
+     * Query the officers service for a given company.
+     *
+     * @param transactionId the ID of the related transaction
+     * @param companyNumber the Company Number
+     * @param ericPassThroughHeader includes authorisation details
+     * @return the list of officers if found
+     * @throws OfficerServiceException if not found or an error occurred
+     * @throws ServiceUnavailableException if public API is unavailable
+     */
+
+    @Override
+    public List<CompanyOfficerApi> getListOfActiveDirectorsDetails(final HttpServletRequest request, final String transactionId,
+        final String companyNumber, final String ericPassThroughHeader)
+        throws OfficerServiceException {
+
+            return getListOfActiveDirectors(
+                getOfficersList(transactionId, companyNumber, ericPassThroughHeader
+                ), request);
+    }
+
+    private OfficersApi getOfficersList(final String transactionId, final String companyNumber, final String ericPassThroughHeader)
+            throws OfficerServiceException {
+        try {
+            final String uri = "/company/" + companyNumber + "/officers";
+            final OfficersApi officersList = apiClientService.getInternalApiClient(ericPassThroughHeader)
+                            .officers()
+                            .list(uri)
+                            .execute()
+                            .getData();
+            logger.debugContext(transactionId, "Retrieved list of Officers", new LogHelper.Builder(transactionId)
+                    .withCompanyNumber(companyNumber)
+                    .build());
+            return officersList;
+        }
+        catch (final URIValidationException | IOException e) {
+            throw new OfficerServiceException("Error Retrieving list of officers for company: " + companyNumber, e);
+        }
+    }
+
+    private List<CompanyOfficerApi> getListOfActiveDirectors(OfficersApi officersList, HttpServletRequest request) {
+        var directorsList = new ArrayList<CompanyOfficerApi>();
+
+        for (CompanyOfficerApi officer : officersList.getItems()) {
+            if (officer != null) {
+                if (officer.getOfficerRole() != null) {
+                    if (ALLOWED_OFFICER_ROLES.contains(officer.getOfficerRole().getOfficerRole()) && officer.getResignedOn() == null) {
+                        directorsList.add(officer);
+                    }
+                }
+                else {
+                    logger.errorRequest(request, "null data was found in the oracle-query-api data within the Role field");
+                }
+            }
+            else {
+                logger.errorRequest(request, "null data was found in the oracle-query-api data, the officer was null");
+            }
+        }
+        return directorsList;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -11,7 +11,6 @@ import uk.gov.companieshouse.api.model.officers.OfficersApi;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
-import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 
 @Service

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -27,14 +27,13 @@ public class OfficerServiceImpl implements OfficerService {
     }
 
     /**
-     * Query the officers service for a given company.
+     * Retrieves list of active Directors
      *
-     * @param transactionId the ID of the related transaction
-     * @param companyNumber the Company Number
-     * @param ericPassThroughHeader includes authorisation details
-     * @return the list of officers if found
-     * @throws OfficerServiceException if not found or an error occurred
-     * @throws ServiceUnavailableException if public API is unavailable
+     * @param companyNumber the company number
+     * @param request the HTTP request
+     * @return the Officers if found
+     *
+     * @throws OfficerServiceException if Officers not found or an error occurred
      */
 
     @Override

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplIT.java
@@ -1,0 +1,108 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.api.interceptor.OpenTransactionInterceptor;
+import uk.gov.companieshouse.api.interceptor.TransactionInterceptor;
+import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
+import uk.gov.companieshouse.api.model.officers.OfficerRoleApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
+import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
+
+@Tag("web")
+@WebMvcTest(controllers = DirectorsControllerImpl.class)
+class DirectorsControllerImplIT {
+    private static final String TRANS_ID = "4f56fdf78b357bfc";
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String USER ="user";
+    private static final String KEY ="key";
+    private static final String KEY_ROLE ="*";
+    @MockBean
+    private OfficerFilingService officerFilingService;
+    @MockBean
+    private LogHelper logHelper;
+    @MockBean
+    private Logger logger;
+    @MockBean
+    private TransactionInterceptor transactionInterceptor;
+    @MockBean
+    private OpenTransactionInterceptor openTransactionInterceptor;
+    @MockBean
+    private OfficerService officerService;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private Transaction transaction;
+    private HttpHeaders httpHeaders;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        httpHeaders = new HttpHeaders();
+        httpHeaders.add("ERIC-Access-Token", PASSTHROUGH_HEADER);
+        httpHeaders.add("ERIC-Identity", USER);
+        httpHeaders.add("ERIC-Identity-Type", KEY);
+        httpHeaders.add("ERIC-Authorised-Key-Roles", KEY_ROLE);
+        httpHeaders.add("ERIC-Authorised-Token-Permissions", "company_officers=readprotected,delete");
+        when(transactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        when(openTransactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(transaction.getStatus()).thenReturn(TransactionStatus.OPEN);
+    }
+
+    @Test
+    void getListOfActiveDirectorsDetailsWhenFoundThen200() throws Exception {
+        var officer = new CompanyOfficerApi();
+        officer.setName("DOE, John James");
+        officer.setOfficerRole(OfficerRoleApi.CORPORATE_DIRECTOR);
+
+        final var officers = Arrays.asList(officer, officer);
+
+        when(officerService.getListOfActiveDirectorsDetails(any(HttpServletRequest.class), eq(TRANS_ID), eq(COMPANY_NUMBER), eq(PASSTHROUGH_HEADER))).thenReturn(officers);
+
+        mockMvc.perform(get("/transactions/{transactionId}/officers/active-directors-details", TRANS_ID)
+                .headers(httpHeaders).requestAttr("transaction", transaction))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)));
+    }
+
+    @Test
+    void getListOfActiveDirectorsDetailsDetailsWhenNotFoundThen500() throws Exception {
+
+        when(officerService.getListOfActiveDirectorsDetails(any(HttpServletRequest.class), eq(TRANS_ID), eq(COMPANY_NUMBER), eq(PASSTHROUGH_HEADER)))
+            .thenThrow(new OfficerServiceException("Error retrieving Officers"));
+
+        mockMvc.perform(get("/transactions/{transactionId}/officers/active-directors-details", TRANS_ID)
+                .headers(httpHeaders).requestAttr("transaction", transaction))
+            .andDo(print())
+            .andExpect(status().isInternalServerError());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplTest.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+@ExtendWith(MockitoExtension.class)
+class DirectorsControllerImplTest {
+
+  private static final String TRANS_ID = "117524-754816-491724";
+  private static final String PASSTHROUGH_HEADER = "passthrough";
+  private static final String COMPANY_NUMBER = "123456";
+  @Mock
+  private Logger logger;
+  @Mock
+  private OfficerService officerService;
+  @Mock
+  private HttpServletRequest request;
+  private DirectorsController testService;
+  private Transaction transaction;
+
+  @BeforeEach
+  void setUp() {
+    testService = new DirectorsControllerImpl(officerService, logger);
+    transaction = new Transaction();
+    transaction.setId(TRANS_ID);
+    transaction.setCompanyNumber(COMPANY_NUMBER);
+
+    when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+  }
+
+  @Test
+  void getListOfActiveDirectorsDetails() throws OfficerServiceException {
+    var officers = Arrays.asList(new CompanyOfficerApi(), new CompanyOfficerApi());
+    when(officerService.getListOfActiveDirectorsDetails(request, TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(officers);
+    var response = testService.getListActiveDirectorsDetails(transaction, request);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(officers, response.getBody());
+  }
+
+  @Test
+  void getListOfActiveDirectorsDetailsThrowsExceptionWhenNotFound() throws OfficerServiceException {
+    when(officerService.getListOfActiveDirectorsDetails(request, TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenThrow(OfficerServiceException.class);
+    var response = testService.getListActiveDirectorsDetails(transaction, request);
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+  }
+
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerTest.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
+
+class DirectorsControllerTest {
+
+  @Mock
+  private HttpServletRequest request;
+  @Mock
+  private Transaction transaction;
+
+
+  @Test
+  void getListActiveDirectorsDetails() {
+
+    var testController = new DirectorsController(){};
+
+    assertThrows(NotImplementedException.class,
+        () -> testController.getListActiveDirectorsDetails(transaction, request));
+  }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImplTest.java
@@ -1,0 +1,96 @@
+package uk.gov.companieshouse.officerfiling.api.service;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.officers.OfficersResourceHandler;
+import uk.gov.companieshouse.api.handler.officers.request.OfficersList;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
+import uk.gov.companieshouse.api.model.officers.OfficerRoleApi;
+import uk.gov.companieshouse.api.model.officers.OfficersApi;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class OfficerServiceImplTest {
+
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String TRANSACTION_ID = "987654321";
+    private static final String URI = "/company/" + COMPANY_NUMBER + "/officers";
+
+    @Mock
+    private ApiClientService apiClientService;
+    @Mock
+    private InternalApiClient internalApiClient;
+    @Mock
+    private OfficersList officersList;
+    @Mock
+    private OfficersResourceHandler officersResourceHandler;
+    @Mock
+    private ApiResponse<OfficersApi> apiResponse;
+    @Mock
+    private Logger logger;
+    @Mock
+    private OfficersApi mockOfficersApi;
+    @Mock
+    private HttpServletRequest request;
+    private OfficerServiceImpl testService;
+
+    @BeforeEach
+    void setUp() {
+        testService = new OfficerServiceImpl(apiClientService, logger);
+    }
+
+    @Test
+    void directorsIsReturnedFromOfficerServiceWhenOfficersRetrieved() throws IOException, URIValidationException {
+        CompanyOfficerApi officer1 = new CompanyOfficerApi();
+        CompanyOfficerApi officer2 = new CompanyOfficerApi();
+        officer1.setOfficerRole(OfficerRoleApi.DIRECTOR);
+        officer2.setOfficerRole(OfficerRoleApi.NOMINEE_SECRETARY);
+        List officersDetails = new ArrayList<CompanyOfficerApi>();
+        officersDetails.add(officer1);
+        officersDetails.add(officer2);
+
+        when(mockOfficersApi.getItems()).thenReturn(officersDetails);
+
+        when(apiResponse.getData()).thenReturn(mockOfficersApi);
+        when(officersList.execute()).thenReturn(apiResponse);
+        when(officersResourceHandler.list(URI)).thenReturn(officersList);
+        when(internalApiClient.officers()).thenReturn(officersResourceHandler);
+        when(apiClientService.getInternalApiClient(PASSTHROUGH_HEADER)).thenReturn(internalApiClient);
+
+        List<CompanyOfficerApi> officers = testService.getListOfActiveDirectorsDetails(request, TRANSACTION_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER);
+
+        assertEquals(officers, officersDetails.subList(0,1));
+    }
+
+    @Test
+    void exceptionIsThrownWhenOfficersNotFound() throws IOException, URIValidationException {
+        when(officersList.execute()).thenThrow(URIValidationException.class);
+        when(officersResourceHandler.list(URI)).thenReturn(officersList);
+        when(internalApiClient.officers()).thenReturn(officersResourceHandler);
+        when(apiClientService.getInternalApiClient(PASSTHROUGH_HEADER)).thenReturn(internalApiClient);
+
+        final var exception = assertThrows(OfficerServiceException.class,
+                () -> testService.getListOfActiveDirectorsDetails(request, TRANSACTION_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER));
+        assertThat(exception.getMessage(),
+            containsString("Error Retrieving list of officers for company: " + COMPANY_NUMBER));
+    }
+}


### PR DESCRIPTION
The current directors page is the 6th page in the happy path journey for the web service. It acts as a page where an Officer may select from a list of active directors associated with a company to remove.

An Officer should be able to click the remove director link which will take them to the ‘When was this director removed ?’ (removal date) page.

To complete this work, we first need an endpoint to retrieve the list of active Directors.

<img width="852" alt="image" src="https://user-images.githubusercontent.com/118275754/229849323-885ff02e-de17-4b07-920b-e3bcedc933c0.png">
