### PR TITLE
DACT-421 Differentiate company appointment 404 errors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/CompanyAppointmentServiceImpl.java
@@ -52,7 +52,12 @@ public class CompanyAppointmentServiceImpl implements CompanyAppointmentService{
             return companyAppointment;
         }
         catch (final ApiErrorResponseException e) {
-            throw new ServiceUnavailableException("The service is down. Try again later");
+            // Temporary hack to differentiate between 404 service is down and 404 appointment not found. When the CA API is fixed to properly differentiate between these two scenarios, this should be fixed to match.
+            if (e.getContent() == null) {
+                throw new CompanyAppointmentServiceException("Error Retrieving appointment " + appointmentId + " for company " + companyNumber, e);
+            } else {
+                throw new ServiceUnavailableException("The service is down. Try again later");
+            }
         }
         catch (final URIValidationException | IOException e) {
             throw new CompanyAppointmentServiceException("Error Retrieving appointment " + appointmentId + " for company " + companyNumber, e);


### PR DESCRIPTION
[DACT-421](https://companieshouse.atlassian.net/browse/DACT-421)
An issue has been found when an invalid appointment ID is sent in a TM01. A service is down response is sent rather than an officer not found error. Discussed how we would handle with Thunderbirds and it was suggested that we make a change to our response body.

[DACT-421]: https://companieshouse.atlassian.net/browse/DACT-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ