### PR TITLE
DACT-410: Dissolved stop screen

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -6,3 +6,4 @@ routes:
   2: ^/transactions/.*/officers
   3: ^/private/transactions/.*/officers
   4: ^/transactions/.*/officers/.*
+  5: ^/officer-filing/company/.*/stop-screen-checks/.*

--- a/routes.yaml
+++ b/routes.yaml
@@ -6,4 +6,4 @@ routes:
   2: ^/transactions/.*/officers
   3: ^/private/transactions/.*/officers
   4: ^/transactions/.*/officers/.*
-  5: ^/officer-filing/company/.*/stop-screen-checks/.*
+  5: ^/officer-filing/company/.*/eligibility-check/.*

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationController.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.ResponseBody;
 import uk.gov.companieshouse.api.company.CompanyProfile;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
@@ -14,12 +15,14 @@ public interface StopScreenValidationController {
      * Check if company has a cessation date.
      *
      * @param companyNumber the company number to check
-     * @param request the servlet request
+     * @param transactionId the transaction id passed for logging
+     * @param request       the servlet request
      * @throws NotImplementedException implementing classes must perform work
      */
     @GetMapping
-    default ResponseEntity<Object> getHasCessationDate(
+    default ResponseEntity<Object> getCurrentOrFutureDissolved(
             @RequestAttribute("companyNumber") String companyNumber,
+            @RequestAttribute("transactionId") String transactionId,
             HttpServletRequest request) {
         throw new NotImplementedException();
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationController.java
@@ -15,14 +15,12 @@ public interface StopScreenValidationController {
      * Check if company has a cessation date.
      *
      * @param companyNumber the company number to check
-     * @param transactionId the transaction id passed for logging
      * @param request       the servlet request
      * @throws NotImplementedException implementing classes must perform work
      */
     @GetMapping
     default ResponseEntity<Object> getCurrentOrFutureDissolved(
             @RequestAttribute("companyNumber") String companyNumber,
-            @RequestAttribute("transactionId") String transactionId,
             HttpServletRequest request) {
         throw new NotImplementedException();
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationController.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationController.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import uk.gov.companieshouse.api.company.CompanyProfile;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface StopScreenValidationController {
+    /**
+     * Check if company has a cessation date.
+     *
+     * @param companyNumber the company number to check
+     * @param request the servlet request
+     * @throws NotImplementedException implementing classes must perform work
+     */
+    @GetMapping
+    default ResponseEntity<Object> getHasCessationDate(
+            @RequestAttribute("companyNumber") String companyNumber,
+            HttpServletRequest request) {
+        throw new NotImplementedException();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
@@ -24,7 +24,7 @@ public class StopScreenValidationControllerImpl implements StopScreenValidationC
 
     @Override
     @ResponseBody
-    @GetMapping(value = "/transactions/{transactionId}/company/{companyNumber}/past-future-dissolved", produces = {"application/json"})
+    @GetMapping(value = "/transactions/{transactionId}/company/{companyNumber}/officers/past-future-dissolved", produces = {"application/json"})
     public ResponseEntity<Object> getCurrentOrFutureDissolved(
             @RequestAttribute("companyNumber") String companyNumber,
             @RequestAttribute("transactionId") String transactionId,

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
@@ -27,7 +27,7 @@ public class StopScreenValidationControllerImpl implements StopScreenValidationC
 
     @Override
     @ResponseBody
-    @GetMapping(value = "/officer-filing/company/{companyNumber}/stop-screen-checks/past-future-dissolved", produces = {"application/json"})
+    @GetMapping(value = "/officer-filing/company/{companyNumber}/eligibility-check/past-future-dissolved", produces = {"application/json"})
     public ResponseEntity<Object> getCurrentOrFutureDissolved(
             @PathVariable("companyNumber") String companyNumber,
             final HttpServletRequest request) {

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
@@ -24,14 +24,15 @@ public class StopScreenValidationControllerImpl implements StopScreenValidationC
 
     @Override
     @ResponseBody
-    @GetMapping(value = "/transactions/{transactionId}/company/{companyNumber}/officers/past-future-dissolved", produces = {"application/json"})
+    @GetMapping(value = "/officer-filing/company/{companyNumber}/past-future-dissolved", produces = {"application/json"})
     public ResponseEntity<Object> getCurrentOrFutureDissolved(
             @RequestAttribute("companyNumber") String companyNumber,
-            @RequestAttribute("transactionId") String transactionId,
             final HttpServletRequest request) {
 
         final var passthroughHeader =
                 request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+
+        final var transactionId = "No Transaction ID";
 
         final var companyProfile = companyProfileService.getCompanyProfile(transactionId, companyNumber, passthroughHeader);
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.ResponseBody;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileServiceImpl;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class StopScreenValidationControllerImpl implements StopScreenValidationController {
+
+    private final Logger logger;
+
+    private final CompanyProfileService companyProfileService;
+
+    public StopScreenValidationControllerImpl(final Logger logger, final CompanyProfileService companyProfileService) {
+        this.logger = logger;
+        this.companyProfileService = companyProfileService;
+    }
+
+    @Override
+    @ResponseBody
+    @GetMapping(value = "/company/{companyNumber}", produces = {"application/json"})
+    public ResponseEntity<Object> getHasCessationDate(
+            @RequestAttribute("companyNumber") String companyNumber,
+            @RequestAttribute("transaction") Transaction transaction,
+            final HttpServletRequest request) {
+
+        final var companyProfile = companyProfileService.getHasCessationDate(companyNumber, transaction, request);
+
+        //check dissolved status too
+
+        if (companyProfile.getDateOfCessation() != null) {
+            return ResponseEntity.status(HttpStatus.OK).body(true);
+        } else {
+            return ResponseEntity.status(HttpStatus.OK).body(false);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
@@ -3,14 +3,17 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
 
+@RestController
 public class StopScreenValidationControllerImpl implements StopScreenValidationController {
 
     private final Logger logger;
@@ -24,9 +27,9 @@ public class StopScreenValidationControllerImpl implements StopScreenValidationC
 
     @Override
     @ResponseBody
-    @GetMapping(value = "/officer-filing/company/{companyNumber}/past-future-dissolved", produces = {"application/json"})
+    @GetMapping(value = "/officer-filing/company/{companyNumber}/stop-screen-checks/past-future-dissolved", produces = {"application/json"})
     public ResponseEntity<Object> getCurrentOrFutureDissolved(
-            @RequestAttribute("companyNumber") String companyNumber,
+            @PathVariable("companyNumber") String companyNumber,
             final HttpServletRequest request) {
 
         final var passthroughHeader =
@@ -36,7 +39,7 @@ public class StopScreenValidationControllerImpl implements StopScreenValidationC
 
         final var companyProfile = companyProfileService.getCompanyProfile(transactionId, companyNumber, passthroughHeader);
 
-        if (companyProfile.getDateOfCessation() != null || companyProfile.getCompanyStatus() == "dissolved") {
+        if (companyProfile.getDateOfCessation() != null || Objects.equals(companyProfile.getCompanyStatus(), "dissolved")){
             return ResponseEntity.status(HttpStatus.OK).body(true);
         } else {
             return ResponseEntity.status(HttpStatus.OK).body(false);

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplTest.java
@@ -54,7 +54,8 @@ class DirectorsControllerImplTest {
 
   @Test
   void getListOfActiveDirectorsDetailsThrowsExceptionWhenNotFound() throws OfficerServiceException {
-    when(officerService.getListOfActiveDirectorsDetails(request, TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenThrow(OfficerServiceException.class);
+    when(officerService.getListOfActiveDirectorsDetails(request, TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER))
+            .thenThrow(OfficerServiceException.class);
     var response = testService.getListActiveDirectorsDetails(transaction, request);
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
   }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImplIT.java
@@ -1,0 +1,90 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
+import uk.gov.companieshouse.api.model.officers.OfficerRoleApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+
+import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
+import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Tag("web")
+@WebMvcTest(controllers = StopScreenValidationControllerImpl.class)
+public class StopScreenValidationControllerImplIT {
+
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+    private static final String COMPANY_NUMBER = "12345678";
+    private CompanyProfileApi companyProfileApi;
+
+    @MockBean
+    private OfficerFilingService officerFilingService;
+    @MockBean
+    private CompanyProfileService companyProfileService;
+
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private Transaction transaction;
+    private HttpHeaders httpHeaders;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        httpHeaders = new HttpHeaders();
+        httpHeaders.add("ERIC-Access-Token", PASSTHROUGH_HEADER);
+
+        companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setCompanyStatus("dissolved"); ;
+        companyProfileApi.setDateOfCessation(null);
+    }
+
+    @Test
+    void getCurrentOrFutureDissolvedWhenFoundThen200() throws Exception {
+        var officer = new CompanyOfficerApi();
+        officer.setName("DOE, John James");
+        officer.setOfficerRole(OfficerRoleApi.CORPORATE_DIRECTOR);
+
+        final var officers = Arrays.asList(officer, officer);
+
+        when(companyProfileService.getCompanyProfile(anyString(), eq(COMPANY_NUMBER), eq(PASSTHROUGH_HEADER))).thenReturn(companyProfileApi);
+
+        mockMvc.perform(get("/officer-filing/company/{companyNumber}/eligibility-check/past-future-dissolved", COMPANY_NUMBER)
+                        .headers(httpHeaders).requestAttr("companyNumber", COMPANY_NUMBER))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    void getCurrentOrFutureDissolvedWhenCompanyProfileServiceNotFoundThen500() throws Exception {
+
+        when(companyProfileService.getCompanyProfile(anyString(), eq(COMPANY_NUMBER), eq(PASSTHROUGH_HEADER)))
+                .thenThrow(new CompanyProfileServiceException("Error Retrieving company profile"));
+
+        mockMvc.perform(get("/officer-filing/company/{companyNumber}/eligibility-check/past-future-dissolved", COMPANY_NUMBER)
+                        .headers(httpHeaders).requestAttr("companyNumber", COMPANY_NUMBER))
+                .andDo(print())
+                .andExpect(status().isInternalServerError());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImplTest.java
@@ -1,0 +1,92 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
+import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class StopScreenValidationControllerImplTest {
+
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+    private static final String COMPANY_NUMBER = "123456";
+
+    private CompanyProfileApi companyProfileApi;
+    @Mock
+    private CompanyProfileService companyProfileService;
+    @Mock
+    private HttpServletRequest request;
+    private StopScreenValidationController testService;
+
+    @BeforeEach
+    void setUp() {
+        testService = new StopScreenValidationControllerImpl(companyProfileService);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+        companyProfileApi = new CompanyProfileApi();
+        companyProfileApi.setCompanyStatus("active"); ;
+        companyProfileApi.setDateOfCessation(null);
+    }
+
+    @Test
+    void getCurrentOrFutureDissolvedReturnsFalse() throws CompanyProfileServiceException {
+        getMockCompanyProfile(companyProfileApi);
+        var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(false, response.getBody());
+    }
+
+    @Test
+    void getCurrentOrFutureDissolvedWithDissolvedStatusReturnsTrue() throws CompanyProfileServiceException {
+        companyProfileApi.setCompanyStatus("dissolved");
+        getMockCompanyProfile(companyProfileApi);
+        var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(true, response.getBody());
+    }
+
+    @Test
+    void getCurrentOrFutureDissolvedWithDateOfCessationReturnsTrue() throws CompanyProfileServiceException {
+        companyProfileApi.setDateOfCessation(LocalDate.of(2023, 1, 1));
+        getMockCompanyProfile(companyProfileApi);
+        var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(true, response.getBody());
+    }
+
+    @Test
+    void getCurrentOrFutureDissolvedWithDissolvedStatusAndDateOfCessationReturnsTrue() throws CompanyProfileServiceException {
+        companyProfileApi.setCompanyStatus("dissolved");
+        companyProfileApi.setDateOfCessation(LocalDate.of(2023, 1, 1));
+        getMockCompanyProfile(companyProfileApi);
+        var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(true, response.getBody());
+    }
+
+    @Test
+    void getCurrentOrFutureDissolvedThrowsExceptionWhenNotFound() throws CompanyProfileServiceException {
+        when(companyProfileService.getCompanyProfile(anyString(), eq(COMPANY_NUMBER), eq(PASSTHROUGH_HEADER)))
+                .thenThrow(CompanyProfileServiceException.class);
+        var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    private void getMockCompanyProfile(CompanyProfileApi companyProfileApi) {
+        when(companyProfileService.getCompanyProfile(anyString(), eq(COMPANY_NUMBER), eq(PASSTHROUGH_HEADER)))
+                .thenReturn(companyProfileApi);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerTest.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.officerfiling.api.controller;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import uk.gov.companieshouse.officerfiling.api.exception.NotImplementedException;
+
+import javax.servlet.http.HttpServletRequest;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class StopScreenValidationControllerTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    void getCurrentOrFutureDissolved() {
+
+        var testController = new StopScreenValidationController(){};
+
+        assertThrows(NotImplementedException.class,
+                () -> testController.getCurrentOrFutureDissolved("companyNumber", request));
+    }
+}


### PR DESCRIPTION
New endpoint for dissolved company stop screen 
[DACT-410](https://companieshouse.atlassian.net/browse/DACT-410):

- API endpoint to return if a company is dissolved or has a cessation date

