### PR TITLE
added feature flag to all endpoints

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImpl.java
@@ -4,6 +4,7 @@ import static uk.gov.companieshouse.officerfiling.api.utils.Constants.TRANSACTIO
 
 import java.util.HashMap;
 import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
 import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper.Builder;
@@ -22,6 +24,8 @@ public class DirectorsControllerImpl implements DirectorsController {
 
     private final OfficerService officerService;
     private final Logger logger;
+    @Value("${FEATURE_FLAG_ENABLE_TM01:true}")
+    private boolean isTm01Enabled;
 
     public DirectorsControllerImpl(final OfficerService officerService, final Logger logger) {
         this.officerService = officerService;
@@ -34,6 +38,10 @@ public class DirectorsControllerImpl implements DirectorsController {
     public ResponseEntity<Object> getListActiveDirectorsDetails(
         @RequestAttribute("transaction") Transaction transaction,
         final HttpServletRequest request) {
+
+        if(!isTm01Enabled){
+            throw new FeatureNotEnabledException();
+        }
 
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transaction.getId());

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/FilingDataControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/FilingDataControllerImpl.java
@@ -2,12 +2,14 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
 import uk.gov.companieshouse.officerfiling.api.service.FilingDataService;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
@@ -17,6 +19,8 @@ import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 public class FilingDataControllerImpl implements FilingDataController {
     private final FilingDataService filingDataService;
     private final Logger logger;
+    @Value("${FEATURE_FLAG_ENABLE_TM01:true}")
+    private boolean isTm01Enabled;
 
     public FilingDataControllerImpl(final FilingDataService filingDataService,
             final Logger logger) {
@@ -39,6 +43,11 @@ public class FilingDataControllerImpl implements FilingDataController {
     public List<FilingApi> getFilingsData(@PathVariable("transactionId") final String transId,
             @PathVariable("filingResourceId") final String filingResourceId,
             final HttpServletRequest request) {
+
+        if(!isTm01Enabled){
+            throw new FeatureNotEnabledException();
+        }
+
         logger.debugContext(transId, "Getting filing data", new LogHelper.Builder(transId)
                         .withFilingId(filingResourceId)
                         .withRequest(request)

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
@@ -17,7 +17,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
 import uk.gov.companieshouse.officerfiling.api.error.InvalidFilingException;
 import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
@@ -30,7 +29,6 @@ import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
 import uk.gov.companieshouse.officerfiling.api.service.TransactionService;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper.Builder;
-import uk.gov.companieshouse.officerfiling.api.validation.OfficerTerminationValidator;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import javax.servlet.http.HttpServletRequest;
@@ -86,13 +84,14 @@ public class OfficerFilingControllerImpl implements OfficerFilingController {
     public ResponseEntity<Object> createFiling(@RequestAttribute("transaction") Transaction transaction,
             @RequestBody @Valid @NotNull final OfficerFilingDto dto,
             final BindingResult bindingResult, final HttpServletRequest request) {
-        logger.debugContext(transaction.getId(), "Creating filing", new LogHelper.Builder(transaction)
-                .withRequest(request)
-                .build());
 
         if(!isTm01Enabled){
             throw new FeatureNotEnabledException();
         }
+
+        logger.debugContext(transaction.getId(), "Creating filing", new LogHelper.Builder(transaction)
+                .withRequest(request)
+                .build());
 
         if (bindingResult != null && bindingResult.hasErrors()) {
             throw new InvalidFilingException(bindingResult.getFieldErrors());
@@ -128,13 +127,14 @@ public class OfficerFilingControllerImpl implements OfficerFilingController {
             @RequestBody @Valid @NotNull final OfficerFilingDto dto,
             @PathVariable("filingResourceId") final String filingResourceId,
             final BindingResult bindingResult, final HttpServletRequest request) {
-        logger.debugContext(transaction.getId(), "Patching Filing", new Builder(transaction)
-                .withRequest(request)
-                .build());
 
         if(!isTm01Enabled){
             throw new FeatureNotEnabledException();
         }
+
+        logger.debugContext(transaction.getId(), "Patching Filing", new Builder(transaction)
+                .withRequest(request)
+                .build());
 
         if (bindingResult != null && bindingResult.hasErrors()) {
             throw new InvalidFilingException(bindingResult.getFieldErrors());
@@ -180,6 +180,10 @@ public class OfficerFilingControllerImpl implements OfficerFilingController {
     public ResponseEntity<OfficerFilingDto> getFilingForReview(
             @PathVariable("transactionId") final String transId,
             @PathVariable("filingResourceId") final String filingResource) {
+
+        if(!isTm01Enabled){
+            throw new FeatureNotEnabledException();
+        }
 
         var maybeOfficerFiling = officerFilingService.get(filingResource, transId);
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImpl.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
 import uk.gov.companieshouse.officerfiling.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
@@ -19,6 +21,8 @@ import java.util.Objects;
 public class StopScreenValidationControllerImpl implements StopScreenValidationController {
 
     private final CompanyProfileService companyProfileService;
+    @Value("${FEATURE_FLAG_ENABLE_TM01:true}")
+    private boolean isTm01Enabled;
 
     public StopScreenValidationControllerImpl(final CompanyProfileService companyProfileService) {
         this.companyProfileService = companyProfileService;
@@ -30,6 +34,10 @@ public class StopScreenValidationControllerImpl implements StopScreenValidationC
     public ResponseEntity<Object> getCurrentOrFutureDissolved(
             @PathVariable("companyNumber") String companyNumber,
             final HttpServletRequest request) {
+
+        if(!isTm01Enabled){
+            throw new FeatureNotEnabledException();
+        }
 
         try {
             final var passthroughHeader =

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImpl.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -13,6 +14,7 @@ import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.enumerations.ApiEnumerations;
 import uk.gov.companieshouse.officerfiling.api.error.ApiErrors;
+import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
 import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
@@ -37,6 +39,8 @@ public class ValidationStatusControllerImpl implements ValidationStatusControlle
     private final OfficerFilingMapper officerFilingMapper;
     private final ErrorMapper errorMapper;
     private final ApiEnumerations apiEnumerations;
+    @Value("${FEATURE_FLAG_ENABLE_TM01:true}")
+    private boolean isTm01Enabled;
 
     public ValidationStatusControllerImpl(OfficerFilingService officerFilingService, Logger logger,
         TransactionService transactionService, CompanyProfileService companyProfileService,
@@ -68,6 +72,10 @@ public class ValidationStatusControllerImpl implements ValidationStatusControlle
         @RequestAttribute("transaction") Transaction transaction,
         @PathVariable("filingResourceId") final String filingResourceId,
         final HttpServletRequest request) {
+
+        if(!isTm01Enabled){
+            throw new FeatureNotEnabledException();
+        }
 
         logger.debugContext(transaction.getId(), "GET validation status request", new LogHelper.Builder(transaction)
                 .withFilingId(filingResourceId)

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -11,9 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
 import uk.gov.companieshouse.officerfiling.api.exception.OfficerServiceException;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
@@ -36,16 +39,16 @@ class DirectorsControllerImplTest {
   @BeforeEach
   void setUp() {
     testService = new DirectorsControllerImpl(officerService, logger);
+    ReflectionTestUtils.setField(testService, "isTm01Enabled", true);
     transaction = new Transaction();
     transaction.setId(TRANS_ID);
     transaction.setCompanyNumber(COMPANY_NUMBER);
-
-    when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
   }
 
   @Test
   void getListOfActiveDirectorsDetails() throws OfficerServiceException {
     var officers = Arrays.asList(new CompanyOfficerApi(), new CompanyOfficerApi());
+    when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
     when(officerService.getListOfActiveDirectorsDetails(request, TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER)).thenReturn(officers);
     var response = testService.getListActiveDirectorsDetails(transaction, request);
     assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -54,10 +57,18 @@ class DirectorsControllerImplTest {
 
   @Test
   void getListOfActiveDirectorsDetailsThrowsExceptionWhenNotFound() throws OfficerServiceException {
+    when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
     when(officerService.getListOfActiveDirectorsDetails(request, TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER))
             .thenThrow(OfficerServiceException.class);
     var response = testService.getListActiveDirectorsDetails(transaction, request);
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+  }
+
+  @Test
+  void checkTm01FeatureFlagDisabled() {
+    ReflectionTestUtils.setField(testService, "isTm01Enabled", false);
+    assertThrows(FeatureNotEnabledException.class,
+        () -> testService.getListActiveDirectorsDetails(transaction, request));
   }
 
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/FilingDataControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/FilingDataControllerImplTest.java
@@ -12,8 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
 import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
 import uk.gov.companieshouse.officerfiling.api.service.FilingDataService;
@@ -43,6 +45,7 @@ class FilingDataControllerImplTest {
     @BeforeEach
     void setUp() {
         testController = new FilingDataControllerImpl(filingDataService, logger);
+        ReflectionTestUtils.setField(testController, "isTm01Enabled", true);
     }
 
     @Test
@@ -66,5 +69,12 @@ class FilingDataControllerImplTest {
         final var exception = assertThrows(ResourceNotFoundException.class,
                 () -> testController.getFilingsData(TRANS_ID, FILING_ID, request));
         assertThat(exception.getMessage(), is("Test Resource not found"));
+    }
+
+    @Test
+    void checkTm01FeatureFlagDisabled(){
+        ReflectionTestUtils.setField(testController, "isTm01Enabled", false);
+        assertThrows(FeatureNotEnabledException.class,
+            () -> testController.getFilingsData(TRANS_ID, FILING_ID, request));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplTest.java
@@ -237,6 +237,8 @@ class OfficerFilingControllerImplTest {
                 () -> testController.createFiling(transaction, dto, result, request));
         assertThrows(FeatureNotEnabledException.class,
                 () -> testController.patchFiling(transaction, dto, null, result, request));
+        assertThrows(FeatureNotEnabledException.class,
+            () -> testController.getFilingForReview(TRANS_ID, FILING_ID));
 
     }
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/StopScreenValidationControllerImplTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
+import uk.gov.companieshouse.officerfiling.api.exception.FeatureNotEnabledException;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
@@ -15,6 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -35,7 +38,7 @@ public class StopScreenValidationControllerImplTest {
     @BeforeEach
     void setUp() {
         testService = new StopScreenValidationControllerImpl(companyProfileService);
-        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
+        ReflectionTestUtils.setField(testService, "isTm01Enabled", true);
         companyProfileApi = new CompanyProfileApi();
         companyProfileApi.setCompanyStatus("active"); ;
         companyProfileApi.setDateOfCessation(null);
@@ -44,6 +47,7 @@ public class StopScreenValidationControllerImplTest {
     @Test
     void getCurrentOrFutureDissolvedReturnsFalse() throws CompanyProfileServiceException {
         getMockCompanyProfile(companyProfileApi);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
         var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(false, response.getBody());
@@ -53,6 +57,7 @@ public class StopScreenValidationControllerImplTest {
     void getCurrentOrFutureDissolvedWithDissolvedStatusReturnsTrue() throws CompanyProfileServiceException {
         companyProfileApi.setCompanyStatus("dissolved");
         getMockCompanyProfile(companyProfileApi);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
         var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(true, response.getBody());
@@ -62,6 +67,7 @@ public class StopScreenValidationControllerImplTest {
     void getCurrentOrFutureDissolvedWithDateOfCessationReturnsTrue() throws CompanyProfileServiceException {
         companyProfileApi.setDateOfCessation(LocalDate.of(2023, 1, 1));
         getMockCompanyProfile(companyProfileApi);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
         var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(true, response.getBody());
@@ -72,6 +78,7 @@ public class StopScreenValidationControllerImplTest {
         companyProfileApi.setCompanyStatus("dissolved");
         companyProfileApi.setDateOfCessation(LocalDate.of(2023, 1, 1));
         getMockCompanyProfile(companyProfileApi);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
         var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(true, response.getBody());
@@ -81,6 +88,7 @@ public class StopScreenValidationControllerImplTest {
     void getCurrentOrFutureDissolvedThrowsExceptionWhenNotFound() throws CompanyProfileServiceException {
         when(companyProfileService.getCompanyProfile(anyString(), eq(COMPANY_NUMBER), eq(PASSTHROUGH_HEADER)))
                 .thenThrow(CompanyProfileServiceException.class);
+        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
         var response = testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
@@ -88,5 +96,12 @@ public class StopScreenValidationControllerImplTest {
     private void getMockCompanyProfile(CompanyProfileApi companyProfileApi) {
         when(companyProfileService.getCompanyProfile(anyString(), eq(COMPANY_NUMBER), eq(PASSTHROUGH_HEADER)))
                 .thenReturn(companyProfileApi);
+    }
+
+    @Test
+    void checkTm01FeatureFlagDisabled(){
+        ReflectionTestUtils.setField(testService, "isTm01Enabled", false);
+        assertThrows(FeatureNotEnabledException.class,
+            () -> testService.getCurrentOrFutureDissolved(COMPANY_NUMBER, request));
     }
 }


### PR DESCRIPTION
As Companies House

I need features flags to be added for filing the removal of a director via web service

So that I can hide features not yet intended for use 

Context

Refers to an engineering team’s ability to turn a feature or functionality on or off at their discretion.  We need to have such a capability in place for the API and Web service, if we realise there is an issue with a service when we release.