### PR TITLE
DACT-489 Add self link to appointment and return name from TM01 post

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <!--- CH -->
         <structured-logging.version>1.9.14</structured-logging.version>
-        <private-api-sdk-java.version>2.0.233</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.262</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <api-security-java.version>0.3.10</api-security-java.version>
         <!--sonar configuration-->

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImpl.java
@@ -1,12 +1,5 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
-import static uk.gov.companieshouse.officerfiling.api.utils.Constants.TRANSACTION_ID_KEY;
-
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.HashMap;
-import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +17,14 @@ import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerService;
 import uk.gov.companieshouse.officerfiling.api.utils.LogHelper.Builder;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.HashMap;
+
+import static uk.gov.companieshouse.officerfiling.api.utils.Constants.TRANSACTION_ID_KEY;
 
 @RestController
 public class DirectorsControllerImpl implements DirectorsController {
@@ -54,9 +55,6 @@ public class DirectorsControllerImpl implements DirectorsController {
         if(!isTm01Enabled){
             throw new FeatureNotEnabledException();
         }
-
-        var logMap = new HashMap<String, Object>();
-        logMap.put(TRANSACTION_ID_KEY, transaction.getId());
 
         try {
             logger.debugContext(transaction.getId(), "Calling service to retrieve the active officers details", new Builder(transaction)

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/filing/FilingResponse.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/filing/FilingResponse.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.officerfiling.api.model.filing;
+
+/**
+ * Response that is sent when an officer filing POST has been processed by the API
+ */
+public class FilingResponse {
+
+    private final String submissionId;
+    private String name;
+
+    public FilingResponse(String submissionId, String name) {
+        this.submissionId = submissionId;
+        this.name = name;
+    }
+
+    public FilingResponse(String submissionId) {
+        this.submissionId = submissionId;
+    }
+
+    public String getSubmissionId() {
+        return submissionId;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplIT.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
-import java.net.URI;
-import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -26,7 +24,6 @@ import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
-import uk.gov.companieshouse.officerfiling.api.model.entity.Links;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
 import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerFilingMapper;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
@@ -34,7 +31,9 @@ import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
 import uk.gov.companieshouse.officerfiling.api.service.TransactionService;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.Instant;
@@ -43,12 +42,10 @@ import java.time.Month;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
-import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
@@ -191,7 +188,8 @@ class OfficerFilingControllerImplIT {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", locationUri.toUriString()))
-                .andExpect(jsonPath("$").value("632c8e65105b1b4a9f0d1f5e"));
+                .andExpect(jsonPath("$.submission_id").value("632c8e65105b1b4a9f0d1f5e"))
+                .andExpect(jsonPath("$.name").value(DIRECTOR_NAME));
         verify(filingMapper).map(dto);
     }
 
@@ -352,6 +350,7 @@ class OfficerFilingControllerImplIT {
                                 .build()) // copy of 'filing' with id=FILING_ID
                 .thenAnswer(i -> OfficerFiling.builder(i.getArgument(0))
                         .build());
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
         when(filingMapper.map(dto)).thenReturn(filing);
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
                         .contentType("application/json")
@@ -484,7 +483,8 @@ class OfficerFilingControllerImplIT {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", locationUri.toUriString()))
-                .andExpect(jsonPath("$").value("632c8e65105b1b4a9f0d1f5e"));
+                .andExpect(jsonPath("$.submission_id").value("632c8e65105b1b4a9f0d1f5e"))
+                .andExpect(jsonPath("$.name").value(DIRECTOR_NAME));
         verify(filingMapper).map(dto);
     }
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -1,23 +1,5 @@
 package uk.gov.companieshouse.officerfiling.api.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import java.io.IOException;
-import java.net.URI;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.Month;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -38,15 +20,32 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.officerfiling.api.exception.CompanyAppointmentServiceException;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
-import uk.gov.companieshouse.officerfiling.api.exception.CompanyProfileServiceException;
 import uk.gov.companieshouse.officerfiling.api.model.mapper.OfficerFilingMapper;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyAppointmentService;
 import uk.gov.companieshouse.officerfiling.api.service.CompanyProfileService;
 import uk.gov.companieshouse.officerfiling.api.service.OfficerFilingService;
 import uk.gov.companieshouse.officerfiling.api.service.TransactionService;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Tag("web")
 @WebMvcTest(controllers = OfficerFilingControllerImpl.class)
@@ -148,6 +147,7 @@ class OfficerFilingControllerImplValidationIT {
                                 .build()) // copy of 'filing' with id=FILING_ID
                 .thenAnswer(i -> OfficerFiling.builder(i.getArgument(0))
                         .build()); // copy of first argument
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
                         .contentType("application/json")
@@ -157,7 +157,7 @@ class OfficerFilingControllerImplValidationIT {
     }
 
     @Test
-    void createFilingWhenReferenceReferenceAppointmentIdBlankThenResponse201() throws Exception {
+    void createFilingWhenReferenceAppointmentIdBlankThenResponse201() throws Exception {
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
         final var body = "{" + TM01_FRAGMENT.replace(FILING_ID, "") + "}";
         final var dto = OfficerFilingDto.builder()
@@ -177,6 +177,7 @@ class OfficerFilingControllerImplValidationIT {
                                 .build()) // copy of 'filing' with id=FILING_ID
                 .thenAnswer(i -> OfficerFiling.builder(i.getArgument(0))
                         .build()); // copy of first argument
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
                 .contentType("application/json")
@@ -210,6 +211,7 @@ class OfficerFilingControllerImplValidationIT {
                                 .build()) // copy of 'filing' with id=FILING_ID
                 .thenAnswer(i -> OfficerFiling.builder(i.getArgument(0))
                         .build()); // copy of first argument
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, FILING_ID, PASSTHROUGH_HEADER)).thenReturn(companyAppointment);
 
         mockMvc.perform(post("/transactions/{id}/officers", TRANS_ID).content(body)
                         .contentType("application/json")


### PR DESCRIPTION
**As** companies house 
**I want** Officer ID for the director I'm trying to be removed to be saved 
**So that** I am able to use the data on future pages and for validation

- Update java SDK to include self link on appointments. Referenced appointment ID can be extracted from this to be used when retrieving current active directors. 
- Add officer name to post response to be set on the web

[DACT-489](https://companieshouse.atlassian.net/browse/DACT-489)

[DACT-489]: https://companieshouse.atlassian.net/browse/DACT-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ