### PR TITLE
Dact 409 no directors stop screen

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImpl.java
@@ -72,6 +72,10 @@ public class DirectorsControllerImpl implements DirectorsController {
             logger.debugContext(transaction.getId(), "Error retrieving active officers details", new Builder(transaction)
                 .withRequest(request)
                 .build());
+            //If the exception contains an empty json, this means the officers could not be found for the company
+            if(e.getCause().getMessage().endsWith("{}")){
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            }
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplTest.java
@@ -58,6 +58,8 @@ class DirectorsControllerImplTest {
   AppointmentFullRecordAPI appointmentFullRecordAPI;
   @Mock
   OfficerFiling officerFiling;
+  @Mock
+  OfficerServiceException serviceException;
   private DirectorsController testService;
   private Transaction transaction;
 
@@ -85,9 +87,11 @@ class DirectorsControllerImplTest {
   void getListOfActiveDirectorsDetailsThrowsExceptionWhenNotFound() throws OfficerServiceException {
     when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(PASSTHROUGH_HEADER);
     when(officerService.getListOfActiveDirectorsDetails(request, TRANS_ID, COMPANY_NUMBER, PASSTHROUGH_HEADER))
-            .thenThrow(OfficerServiceException.class);
+            .thenThrow(serviceException);
+    when(serviceException.getCause()).thenReturn(serviceException);
+    when(serviceException.getMessage()).thenReturn("404 not found\n{}");
     var response = testService.getListActiveDirectorsDetails(transaction, request);
-    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
   }
 
   @Test


### PR DESCRIPTION
Forward the 404 response in active-directors-details endpoint returned by the public data API when no officers are found for a company