### PR TITLE
Remove DOB requirement for corporate director filings

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -88,7 +88,7 @@ public class FilingDataServiceImpl implements FilingDataService {
                     enhancedOfficerFilingBuilder = enhancedOfficerFilingBuilder.dateOfBirth(new Date3Tuple(companyAppointment.getDateOfBirth()));
                 }
 
-        OfficerFiling enhancedOfficerFiling = enhancedOfficerFilingBuilder.build();
+        var enhancedOfficerFiling = enhancedOfficerFilingBuilder.build();
         var filingData = filingMapper.mapFiling(enhancedOfficerFiling);
         var dataMap = MapHelper.convertObject(filingData, PropertyNamingStrategies.SNAKE_CASE);
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -80,11 +80,15 @@ public class FilingDataServiceImpl implements FilingDataService {
         final AppointmentFullRecordAPI companyAppointment = companyAppointmentService.getCompanyAppointment(transactionId, companyNumber,
                 appointmentId, ericPassThroughHeader);
 
-        var enhancedOfficerFiling = OfficerFiling.builder(officerFiling)
-                .dateOfBirth(new Date3Tuple(companyAppointment.getDateOfBirth()))
+        var enhancedOfficerFilingBuilder = OfficerFiling.builder(officerFiling)
                 .name(companyAppointment.getName())
-                .corporateDirector(mapCorporateDirector(transaction, companyAppointment))
-                .build();
+                .corporateDirector(mapCorporateDirector(transaction, companyAppointment));
+                // For non corporate Directors
+                if(companyAppointment.getDateOfBirth() != null){
+                    enhancedOfficerFilingBuilder = enhancedOfficerFilingBuilder.dateOfBirth(new Date3Tuple(companyAppointment.getDateOfBirth()));
+                }
+
+        OfficerFiling enhancedOfficerFiling = enhancedOfficerFilingBuilder.build();
         var filingData = filingMapper.mapFiling(enhancedOfficerFiling);
         var dataMap = MapHelper.convertObject(filingData, PropertyNamingStrategies.SNAKE_CASE);
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
@@ -75,6 +75,47 @@ class FilingDataServiceImplTest {
 
     @Test
     void generateOfficerFilingWhenFound() {
+        final var filingData = new FilingData(FIRSTNAME, LASTNAME, DATE_OF_BIRTH_STR, RESIGNED_ON_STR, true);
+        final var officerFiling = OfficerFiling.builder()
+                .referenceAppointmentId(REF_APPOINTMENT_ID)
+                .firstName(FIRSTNAME)
+                .lastName(LASTNAME)
+                .resignedOn(RESIGNED_ON_INS)
+                .dateOfBirth(DATE_OF_BIRTH_TUPLE)
+                .build();
+
+        SensitiveDateOfBirthAPI dateOfBirthAPI = new SensitiveDateOfBirthAPI();
+        dateOfBirthAPI.setDay(20);
+        dateOfBirthAPI.setMonth(10);
+        dateOfBirthAPI.setYear(2000);
+
+        when(companyAppointment.getDateOfBirth()).thenReturn(dateOfBirthAPI);
+        when(companyAppointment.getOfficerRole()).thenReturn("director");
+        when(companyAppointment.getForename()).thenReturn(FIRSTNAME);
+        when(companyAppointment.getSurname()).thenReturn(LASTNAME);
+        when(officerFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(officerFiling));
+        when(officerFilingMapper.mapFiling(officerFiling)).thenReturn(filingData);
+        when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
+        when(companyAppointmentService.getCompanyAppointment(TRANS_ID, COMPANY_NUMBER, REF_APPOINTMENT_ID, PASSTHROUGH_HEADER ))
+                .thenReturn(companyAppointment);
+        when(dateNowSupplier.get()).thenReturn(DUMMY_DATE);
+
+        final var filingApi = testService.generateOfficerFiling(TRANS_ID, FILING_ID, PASSTHROUGH_HEADER);
+
+        final Map<String, Object> expectedMap =
+                Map.of("first_name", FIRSTNAME, "last_name", LASTNAME,
+                        "date_of_birth", DATE_OF_BIRTH_STR,
+                        "resigned_on", RESIGNED_ON_STR,
+                        "is_corporate_director", true);
+
+        assertThat(filingApi.getData(), is(equalTo(expectedMap)));
+        assertThat(filingApi.getKind(), is("officer-filing#termination"));
+        assertThat(filingApi.getDescription(), is("(TM01) Termination of appointment of director. Terminating appointment of "
+            + FIRSTNAME + " " + LASTNAME.toUpperCase()  + " on 16 March 2023"));
+    }
+
+    @Test
+    void generateCorporateOfficerFilingWhenFound() {
         final var filingData = new FilingData(FIRSTNAME, LASTNAME, null, RESIGNED_ON_STR, true);
         final var officerFiling = OfficerFiling.builder()
                 .referenceAppointmentId(REF_APPOINTMENT_ID)
@@ -103,7 +144,7 @@ class FilingDataServiceImplTest {
         assertThat(filingApi.getData(), is(equalTo(expectedMap)));
         assertThat(filingApi.getKind(), is("officer-filing#termination"));
         assertThat(filingApi.getDescription(), is("(TM01) Termination of appointment of director. Terminating appointment of "
-            + FIRSTNAME + " " + LASTNAME.toUpperCase()  + " on 16 March 2023"));
+                + FIRSTNAME + " " + LASTNAME.toUpperCase()  + " on 16 March 2023"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
@@ -75,21 +75,14 @@ class FilingDataServiceImplTest {
 
     @Test
     void generateOfficerFilingWhenFound() {
-        final var filingData = new FilingData(FIRSTNAME, LASTNAME, DATE_OF_BIRTH_STR, RESIGNED_ON_STR, true);
+        final var filingData = new FilingData(FIRSTNAME, LASTNAME, null, RESIGNED_ON_STR, true);
         final var officerFiling = OfficerFiling.builder()
                 .referenceAppointmentId(REF_APPOINTMENT_ID)
                 .firstName(FIRSTNAME)
                 .lastName(LASTNAME)
                 .resignedOn(RESIGNED_ON_INS)
-                .dateOfBirth(DATE_OF_BIRTH_TUPLE)
                 .build();
 
-        SensitiveDateOfBirthAPI dateOfBirthAPI = new SensitiveDateOfBirthAPI();
-        dateOfBirthAPI.setDay(20);
-        dateOfBirthAPI.setMonth(10);
-        dateOfBirthAPI.setYear(2000);
-
-        when(companyAppointment.getDateOfBirth()).thenReturn(dateOfBirthAPI);
         when(companyAppointment.getOfficerRole()).thenReturn("corporate-director");
         when(companyAppointment.getForename()).thenReturn(FIRSTNAME);
         when(companyAppointment.getSurname()).thenReturn(LASTNAME);
@@ -104,7 +97,6 @@ class FilingDataServiceImplTest {
 
         final Map<String, Object> expectedMap =
                 Map.of("first_name", FIRSTNAME, "last_name", LASTNAME,
-                        "date_of_birth", DATE_OF_BIRTH_STR,
                         "resigned_on", RESIGNED_ON_STR,
                         "is_corporate_director", true);
 


### PR DESCRIPTION
Remove DOB requirement for corporate director filings

Issue occurred when a TM01 request was sent for a corporate director. The callback from the filing resource handler would fail. API would throw an exception trying to convert the non existent date to a date3tuple. Exception as seen in https://companieshouse.atlassian.net/browse/DACT-610.

Fix allows the filing resource handler to return as expected.