### PR TITLE
DACT-503: Pagination up to 100 directors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -49,14 +49,14 @@ public class OfficerServiceImpl implements OfficerService {
     private OfficersApi getOfficersList(final String transactionId, final String companyNumber, final String ericPassThroughHeader)
             throws OfficerServiceException {
         try {
-            final String uri = "/company/" + companyNumber + "/officers";
-            final OfficersList officersList = apiClientService.getInternalApiClient(ericPassThroughHeader)
+            final var uri = "/company/" + companyNumber + "/officers";
+            final var officersList = apiClientService.getInternalApiClient(ericPassThroughHeader)
                             .officers()
                             .list(uri);
 
             officersList.addQueryParams("items_per_page", "100");
 
-            final OfficersApi officersApi = officersList.execute()
+            final var officersApi = officersList.execute()
                     .getData();
 
             logger.debugContext(transactionId, "Retrieved list of Officers", new LogHelper.Builder(transactionId)

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -6,7 +6,6 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
-import uk.gov.companieshouse.api.handler.officers.request.OfficersList;
 import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
 import uk.gov.companieshouse.api.model.officers.OfficersApi;
 import uk.gov.companieshouse.api.sdk.ApiClientService;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.officers.request.OfficersList;
 import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
 import uk.gov.companieshouse.api.model.officers.OfficersApi;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
@@ -49,15 +50,19 @@ public class OfficerServiceImpl implements OfficerService {
             throws OfficerServiceException {
         try {
             final String uri = "/company/" + companyNumber + "/officers";
-            final OfficersApi officersList = apiClientService.getInternalApiClient(ericPassThroughHeader)
+            final OfficersList officersList = apiClientService.getInternalApiClient(ericPassThroughHeader)
                             .officers()
-                            .list(uri)
-                            .execute()
-                            .getData();
+                            .list(uri);
+
+            officersList.addQueryParams("items_per_page", "100");
+
+            final OfficersApi officersApi = officersList.execute()
+                    .getData();
+
             logger.debugContext(transactionId, "Retrieved list of Officers", new LogHelper.Builder(transactionId)
                     .withCompanyNumber(companyNumber)
                     .build());
-            return officersList;
+            return officersApi;
         }
         catch (final URIValidationException | IOException e) {
             throw new OfficerServiceException("Error Retrieving list of officers for company: " + companyNumber, e);


### PR DESCRIPTION
The active directors page should now show one hundred entries. Five per page with twenty pages.

taf-api-karate branch DACT-439_pagination_testing has a feature file named insert_directors.feature which can be run to add the required directors. 