### PR TITLE
DACT-341 Add first middle and last names to filing dto

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImpl.java
@@ -38,6 +38,7 @@ import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.HashMap;
@@ -303,10 +304,9 @@ public class OfficerFilingControllerImpl implements OfficerFilingController {
     }
 
     private Optional<Instant> getResignedOnFromDto(OfficerFilingDto dto) {
-        if (dto.getResignedOn() != null) {
-            return Optional.of(dto.getResignedOn().atStartOfDay().toInstant(ZoneOffset.UTC));
-        }
-        return Optional.empty();
+        return Optional.ofNullable(dto.getResignedOn())
+                .map(LocalDate::atStartOfDay)
+                .map(d -> d.toInstant(ZoneOffset.UTC));
     }
 
     private String getExistingFilingId(Transaction transaction){

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/OfficerFilingDto.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/OfficerFilingDto.java
@@ -2,6 +2,8 @@ package uk.gov.companieshouse.officerfiling.api.model.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.springframework.validation.annotation.Validated;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +13,6 @@ import java.util.StringJoiner;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.springframework.validation.annotation.Validated;
 
 @JsonDeserialize(builder = OfficerFilingDto.Builder.class)
 @Validated
@@ -25,6 +26,9 @@ public class OfficerFilingDto {
     private List<FormerNameDto> formerNames;
     private IdentificationDto identification;
     private String name;
+    private String firstName;
+    private String middleNames;
+    private String lastName;
     private String nationality;
     private String occupation;
     private String referenceEtag;
@@ -67,6 +71,18 @@ public class OfficerFilingDto {
 
     public String getName() {
         return name;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getMiddleNames() {
+        return middleNames;
+    }
+
+    public String getLastName() {
+        return lastName;
     }
 
     public String getNationality() {
@@ -119,6 +135,9 @@ public class OfficerFilingDto {
                 && Objects.equals(getFormerNames(), that.getFormerNames())
                 && Objects.equals(getIdentification(), that.getIdentification())
                 && Objects.equals(getName(), that.getName())
+                && Objects.equals(getFirstName(), that.getFirstName())
+                && Objects.equals(getMiddleNames(), that.getMiddleNames())
+                && Objects.equals(getLastName(), that.getLastName())
                 && Objects.equals(getNationality(), that.getNationality())
                 && Objects.equals(getOccupation(), that.getOccupation())
                 && Objects.equals(getReferenceEtag(), that.getReferenceEtag())
@@ -134,7 +153,8 @@ public class OfficerFilingDto {
     public int hashCode() {
         return Objects.hash(getAddress(), getAddressSameAsRegisteredOfficeAddress(),
                 getAppointedOn(), getCountryOfResidence(), getDateOfBirth(), getFormerNames(),
-                getIdentification(), getName(), getNationality(), getOccupation(),
+                getIdentification(), getName(),
+                getFirstName(), getMiddleNames(), getLastName(), getNationality(), getOccupation(),
                 getReferenceEtag(), getReferenceAppointmentId(), getReferenceOfficerListEtag(),
                 getResignedOn(), getResidentialAddress(),
                 getResidentialAddressSameAsCorrespondenceAddress());
@@ -151,6 +171,9 @@ public class OfficerFilingDto {
                 .add("formerNames=" + formerNames)
                 .add("identification=" + identification)
                 .add("name='" + name + "'")
+                .add("firstName='" + firstName + "'")
+                .add("middleNames='" + middleNames + "'")
+                .add("lastName='" + lastName + "'")
                 .add("nationality='" + nationality + "'")
                 .add("occupation='" + occupation + "'")
                 .add("referenceEtag='" + referenceEtag + "'")
@@ -235,6 +258,24 @@ public class OfficerFilingDto {
         public Builder name(final String value) {
 
             buildSteps.add(data -> data.name = value);
+            return this;
+        }
+
+        public Builder firstName(final String value) {
+
+            buildSteps.add(data -> data.firstName = value);
+            return this;
+        }
+
+        public Builder middleNames(final String value) {
+
+            buildSteps.add(data -> data.middleNames = value);
+            return this;
+        }
+
+        public Builder lastName(final String value) {
+
+            buildSteps.add(data -> data.lastName = value);
             return this;
         }
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/OfficerFiling.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/OfficerFiling.java
@@ -1,6 +1,9 @@
 package uk.gov.companieshouse.officerfiling.api.model.entity;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -8,8 +11,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "officer_filing")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -162,6 +163,7 @@ public class OfficerFiling {
                                     .formerNames(v.getFormerNames())
                                     .name(v.getName())
                                     .firstName(v.getFirstName())
+                                    .middleNames(v.getMiddleNames())
                                     .lastName(v.getLastName())
                                     .nationality(v.getNationality())
                                     .occupation(v.getOccupation())

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/OfficerFilingData.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/OfficerFilingData.java
@@ -22,6 +22,7 @@ public class OfficerFilingData {
     private List<FormerName> formerNames;
     private String name;
     private String firstName;
+    private String middleNames;
     private String lastName;
     private String nationality;
     private String occupation;
@@ -86,6 +87,10 @@ public class OfficerFilingData {
 
     public String getFirstName() {
         return firstName;
+    }
+
+    public String getMiddleNames() {
+        return middleNames;
     }
 
     public String getLastName() {
@@ -154,6 +159,7 @@ public class OfficerFilingData {
                 && Objects.equals(getFormerNames(), that.getFormerNames())
                 && Objects.equals(getName(), that.getName())
                 && Objects.equals(getFirstName(), that.getFirstName())
+                && Objects.equals(getMiddleNames(), that.getMiddleNames())
                 && Objects.equals(getLastName(), that.getLastName())
                 && Objects.equals(getNationality(), that.getNationality())
                 && Objects.equals(getOccupation(), that.getOccupation())
@@ -173,7 +179,7 @@ public class OfficerFilingData {
         return Objects.hash(getAddress(), getAddressSameAsRegisteredOfficeAddress(),
                 getAppointedOn(), getCountryOfResidence(), getDateOfBirth(),
                 getFormerNames(), getName(),
-                getFirstName(), getLastName(), getNationality(), getOccupation(), getOfficerRole(),
+                getFirstName(), getMiddleNames(), getLastName(), getNationality(), getOccupation(), getOfficerRole(),
                 getReferenceEtag(), getReferenceAppointmentId(), getReferenceOfficerListEtag(),
                 getResignedOn(), getStatus(), getResidentialAddress(),
                 getResidentialAddressSameAsCorrespondenceAddress());
@@ -190,6 +196,7 @@ public class OfficerFilingData {
                 .add("formerNames=" + formerNames)
                 .add("name='" + name + "'")
                 .add("firstName='" + firstName + "'")
+                .add("middleNames='" + middleNames + "'")
                 .add("lastName='" + lastName + "'")
                 .add("nationality='" + nationality + "'")
                 .add("occupation='" + occupation + "'")
@@ -220,7 +227,7 @@ public class OfficerFilingData {
 
         private final List<Consumer<OfficerFilingData>> buildSteps;
 
-        private Builder() {
+        public Builder() {
             buildSteps = new ArrayList<>();
         }
 
@@ -236,6 +243,7 @@ public class OfficerFilingData {
                     .formerNames(other.getFormerNames())
                     .name(other.getName())
                     .firstName(other.getFirstName())
+                    .middleNames(other.getMiddleNames())
                     .lastName(other.getLastName())
                     .nationality(other.getNationality())
                     .occupation(other.getOccupation())
@@ -304,6 +312,12 @@ public class OfficerFilingData {
         public Builder firstName(final String value) {
 
             buildSteps.add(data -> data.firstName = value);
+            return this;
+        }
+
+        public Builder middleNames(final String value) {
+
+            buildSteps.add(data -> data.middleNames = value);
             return this;
         }
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerFilingMapper.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/mapper/OfficerFilingMapper.java
@@ -1,16 +1,17 @@
 package uk.gov.companieshouse.officerfiling.api.model.mapper;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import uk.gov.companieshouse.officerfiling.api.model.dto.OfficerFilingDto;
 import uk.gov.companieshouse.officerfiling.api.model.entity.Date3Tuple;
 import uk.gov.companieshouse.officerfiling.api.model.entity.OfficerFiling;
 import uk.gov.companieshouse.officerfiling.api.model.filing.FilingData;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 @Mapper(componentModel = "spring")
 public interface OfficerFilingMapper {
@@ -29,6 +30,9 @@ public interface OfficerFilingMapper {
     @Mapping(target = "data.nationality", source = "nationality")
     @Mapping(target = "data.occupation", source = "occupation")
     @Mapping(target = "data.name", source = "name")
+    @Mapping(target = "data.firstName", source = "firstName")
+    @Mapping(target = "data.middleNames", source = "middleNames")
+    @Mapping(target = "data.lastName", source = "lastName")
     @Mapping(target = "data.referenceEtag", source = "referenceEtag")
     @Mapping(target = "data.referenceAppointmentId", source = "referenceAppointmentId")
     @Mapping(target = "data.referenceOfficerListEtag", source = "referenceOfficerListEtag")
@@ -47,6 +51,9 @@ public interface OfficerFilingMapper {
     @Mapping(target = "nationality", source = "data.nationality")
     @Mapping(target = "occupation", source = "data.occupation")
     @Mapping(target = "name", source = "data.name")
+    @Mapping(target = "firstName", source = "data.firstName")
+    @Mapping(target = "middleNames", source = "data.middleNames")
+    @Mapping(target = "lastName", source = "data.lastName")
     @Mapping(target = "referenceEtag", source = "data.referenceEtag")
     @Mapping(target = "referenceAppointmentId", source = "data.referenceAppointmentId")
     @Mapping(target = "referenceOfficerListEtag", source = "data.referenceOfficerListEtag")


### PR DESCRIPTION
Currently officer filing dto accepts name as a single field. This has been split into 3 separate fields and needs to be reflected in the api.
[DACT-341](https://companieshouse.atlassian.net/browse/DACT-341)

[DACT-341]: https://companieshouse.atlassian.net/browse/DACT-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ