### PR TITLE
Dact 707 directors occupation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/enumerations/ValidationEnum.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/enumerations/ValidationEnum.java
@@ -35,7 +35,9 @@ public enum ValidationEnum {
     FORMER_NAMES_CHARACTERS("former-names-characters"),
     DATE_OF_BIRTH_BLANK("date-of-birth-blank"),
     DATE_OF_BIRTH_OVERAGE("date-of-birth-overage"),
-    DATE_OF_BIRTH_UNDERAGE("date-of-birth-underage");
+    DATE_OF_BIRTH_UNDERAGE("date-of-birth-underage"),
+    OCCUPATION_LENGTH("occupation-length"),
+    OCCUPATION_CHARACTERS("occupation-characters");
 
 
     private final String key;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -83,6 +83,7 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateTitle(request, errorList, dto);
         validateMiddleNames(request, errorList, dto);
         validateFormerNames(request, errorList, dto);
+        validateOccupation(request, errorList, dto);
     }
 
     private void validateFirstName(HttpServletRequest request, List<ApiError> errorList, OfficerFilingDto dto){
@@ -188,6 +189,19 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         }
         if (Objects.equals(companyProfile.getCompanyStatus(), "dissolved") || companyProfile.getDateOfCessation() != null) {
             createValidationError(request, errorList, getApiEnumerations().getValidation(ValidationEnum.COMPANY_DISSOLVED));
+        }
+    }
+
+    private void validateOccupation(HttpServletRequest request, List<ApiError> errorList, OfficerFilingDto dto){
+        if(dto.getOccupation() != null){
+            if (!validateDtoFieldLength(dto.getOccupation(), 100)) {
+                createValidationError(request, errorList,
+                        apiEnumerations.getValidation(ValidationEnum.OCCUPATION_LENGTH));
+            }
+            if (!isValidCharacters(dto.getOccupation())) {
+                createValidationError(request, errorList,
+                        apiEnumerations.getValidation(ValidationEnum.OCCUPATION_CHARACTERS));
+            }
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmnetValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmnetValidatorTest.java
@@ -598,6 +598,7 @@ class OfficerAppointmnetValidatorTest {
         when(transaction.getId()).thenReturn(TRANS_ID);
         when(dto.getFirstName()).thenReturn("John");
         when(dto.getLastName()).thenReturn("Smith");
+        when(dto.getOccupation()).thenReturn("Engineer");
         when(apiEnumerations.getValidation(ValidationEnum.DATE_OF_BIRTH_BLANK)).thenReturn(
                 "Enter the director’s date of birth");
 
@@ -607,6 +608,48 @@ class OfficerAppointmnetValidatorTest {
                 .hasSize(1)
                 .extracting(ApiError::getError)
                 .contains("Enter the director’s date of birth");
+    }
+
+    @Test
+    void validateOccupationCharacters() {
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(dto.getFirstName()).thenReturn("John");
+        when(dto.getLastName()).thenReturn("Smith");
+        when(dto.getDateOfBirth()).thenReturn(new Date3TupleDto(25,1,1993));
+        when(dto.getOccupation()).thenReturn("Engineerゃ");
+
+        when(apiEnumerations.getValidation(ValidationEnum.OCCUPATION_CHARACTERS)).thenReturn(
+                "Occupation must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes");
+
+        final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
+                PASSTHROUGH_HEADER);
+        assertThat(apiErrors.getErrors())
+                .as("An error should be produced when occupation contains illegal characters")
+                .hasSize(1)
+                .extracting(ApiError::getError)
+                .contains("Occupation must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes");
+    }
+
+    @Test
+    void validateOccupationLength() {
+        when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(transaction.getId()).thenReturn(TRANS_ID);
+        when(dto.getFirstName()).thenReturn("John");
+        when(dto.getLastName()).thenReturn("Smith");
+        when(dto.getDateOfBirth()).thenReturn(new Date3TupleDto(25,1,1993));
+        when(dto.getOccupation()).thenReturn("EngineerEngineerEngineerEngineerEngineerEngineerEngineerEngineerEngineerEngineerEngineerEngineerEngineer");
+
+        when(apiEnumerations.getValidation(ValidationEnum.OCCUPATION_LENGTH)).thenReturn(
+                "Occupation must be 100 characters or less");
+
+        final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
+                PASSTHROUGH_HEADER);
+        assertThat(apiErrors.getErrors())
+                .as("An error should be produced when occupation contains more than 100 characters")
+                .hasSize(1)
+                .extracting(ApiError::getError)
+                .contains("Occupation must be 100 characters or less");
     }
 
 }


### PR DESCRIPTION
Add validation for a directors occupation.
Occupation is an optional field and should be less than 100 characters in length. Should follow charset 2 as referenced at https://companieshouse.atlassian.net/browse/DACT-707