### PR TITLE
DACT-747-Former-Names

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/OfficerFilingDto.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/OfficerFilingDto.java
@@ -11,8 +11,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @JsonDeserialize(builder = OfficerFilingDto.Builder.class)
 @Validated
@@ -23,7 +21,7 @@ public class OfficerFilingDto {
     private LocalDate appointedOn;
     private String countryOfResidence;
     private Date3TupleDto dateOfBirth;
-    private List<FormerNameDto> formerNames;
+    private String formerNames;
     private IdentificationDto identification;
     private String name;
     private String title;
@@ -62,7 +60,7 @@ public class OfficerFilingDto {
         return dateOfBirth;
     }
 
-    public List<FormerNameDto> getFormerNames() {
+    public String getFormerNames() {
         return formerNames;
     }
 
@@ -240,14 +238,9 @@ public class OfficerFilingDto {
             return this;
         }
 
-        public Builder formerNames(final List<FormerNameDto> value) {
+        public Builder formerNames(final String value) {
 
-            buildSteps.add(data -> data.formerNames = value == null
-                    ? null
-                    : value.stream()
-                            .flatMap(Stream::ofNullable)
-                            .map(v -> new FormerNameDto(v.getForenames(), v.getSurname()))
-                            .collect(Collectors.toList()));
+            buildSteps.add(data -> data.formerNames = value);
             return this;
         }
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/OfficerFilingData.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/entity/OfficerFilingData.java
@@ -8,8 +8,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OfficerFilingData {
@@ -19,7 +17,7 @@ public class OfficerFilingData {
     private Instant appointedOn;
     private String countryOfResidence;
     private Date3Tuple dateOfBirth;
-    private List<FormerName> formerNames;
+    private String formerNames;
     private String name;
     private String title;
     private String firstName;
@@ -78,7 +76,7 @@ public class OfficerFilingData {
         return dateOfBirth;
     }
 
-    public List<FormerName> getFormerNames() {
+    public String getFormerNames() {
         return formerNames;
     }
 
@@ -300,13 +298,9 @@ public class OfficerFilingData {
             return this;
         }
 
-        public Builder formerNames(final List<FormerName> value) {
-            buildSteps.add(data -> data.formerNames = value == null
-                    ? null
-                    : value.stream()
-                            .flatMap(Stream::ofNullable)
-                            .map(v -> new FormerName(v.getForenames(), v.getSurname()))
-                            .collect(Collectors.toList()));
+        public Builder formerNames(final String value) {
+
+            buildSteps.add(data -> data.formerNames = value);
             return this;
         }
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -135,15 +135,13 @@ public class OfficerAppointmentValidator extends OfficerValidator {
                 createValidationError(request, errorList,
                         apiEnumerations.getValidation(ValidationEnum.FORMER_NAMES_LENGTH));
             }
-            for(var formerName : dto.getFormerNames()){
-                if(!isValidCharacters(formerName.getSurname()) || !isValidCharacters(formerName.getForenames())){
-                    createValidationError(request, errorList,
-                            apiEnumerations.getValidation(ValidationEnum.FORMER_NAMES_CHARACTERS));
-                    break;
-                }
+            if(!isValidCharacters(dto.getFormerNames())) {
+                createValidationError(request, errorList,
+                        apiEnumerations.getValidation(ValidationEnum.FORMER_NAMES_CHARACTERS));
             }
         }
     }
+
     @Override
     public void validateRequiredTransactionFields(HttpServletRequest request, List<ApiError> errorList, Transaction transaction) {
         if (transaction.getCompanyNumber() == null || transaction.getCompanyNumber().isBlank()) {

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerValidator.java
@@ -179,12 +179,8 @@ public class OfficerValidator {
         return field.length() <= maxLength;
     }
 
-    public boolean validateFormerNamesLength(List<FormerNameDto> formerNames){
-        var length = 0;
-        for(var formerName : formerNames){
-            length = length + formerName.getForenames().length() + formerName.getSurname().length();
-        }
-        return length <= 160;
+    public boolean validateFormerNamesLength(String formerNames){
+        return formerNames.length() <= 160;
     }
 
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerFilingDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/OfficerFilingDataServiceImplTest.java
@@ -97,16 +97,13 @@ class OfficerFilingDataServiceImplTest {
 
     @Test
     void testMergeFull(){
-        List<FormerName> formerNames = new ArrayList<>(1);
-        FormerName formerName = new FormerName("John", "Doe");
-        formerNames.add(formerName);
         var address = Address.builder().locality("Margate").country("UK").build();
         var identification = new Identification("type", "authority",
                 "form", "registered", "number");
         OfficerFilingData originalData = OfficerFilingData.builder()
                 .referenceEtag("ETAG")
                 .resignedOn(Instant.parse("2022-09-13T00:00:00Z"))
-                .formerNames(formerNames)
+                .formerNames("John,Doe")
                 .address(address)
                 .build();
         OfficerFiling original = OfficerFiling.builder()
@@ -123,8 +120,7 @@ class OfficerFilingDataServiceImplTest {
         assertThat(updatedFiling.getData().getReferenceEtag(), is("ETAG"));
         assertThat(updatedFiling.getData().getReferenceAppointmentId(), is("Appoint"));
         assertThat(updatedFiling.getData().getResignedOn(), is(Instant.parse("2022-09-13T00:00:00Z")));
-        assertThat(updatedFiling.getData().getFormerNames().get(0).getForenames(), is("John"));
-        assertThat(updatedFiling.getData().getFormerNames().get(0).getSurname(), is("Doe"));
+        assertThat(updatedFiling.getData().getFormerNames(), is("John,Doe"));
         assertThat(updatedFiling.getData().getAddress().getLocality(), is("Margate"));
         assertThat(updatedFiling.getData().getAddress().getCountry(), is("UK"));
         assertThat(updatedFiling.getIdentification().getIdentificationType(), is("type"));

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmnetValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmnetValidatorTest.java
@@ -372,7 +372,7 @@ class OfficerAppointmnetValidatorTest {
         when(dto.getLastName()).thenReturn("Smith");
         when(dto.getMiddleNames()).thenReturn("Doe");
         when(dto.getTitle()).thenReturn("MrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMr");
-        when(dto.getFormerNames()).thenReturn(formerNameList);
+        when(dto.getFormerNames()).thenReturn("Anton,Doe");
 
         when(apiEnumerations.getValidation(ValidationEnum.TITLE_LENGTH)).thenReturn(
                 "Title can be no longer than 50 characters");
@@ -388,16 +388,14 @@ class OfficerAppointmnetValidatorTest {
 
     @Test
     void validateFormerNameLength() {
-        FormerNameDto formerNames = new FormerNameDto("JamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJames","Francis");
-        List<FormerNameDto> formerNameList = new ArrayList<>(1);
-        formerNameList.add(formerNames);
+        String formerNames = "JamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJamesJames,Francis";
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(transaction.getId()).thenReturn(TRANS_ID);
         when(dto.getFirstName()).thenReturn("John");
         when(dto.getLastName()).thenReturn("Smith");
         when(dto.getMiddleNames()).thenReturn("Doe");
         when(dto.getTitle()).thenReturn("Mr");
-        when(dto.getFormerNames()).thenReturn(formerNameList);
+        when(dto.getFormerNames()).thenReturn(formerNames);
         when(apiEnumerations.getValidation(ValidationEnum.FORMER_NAMES_LENGTH)).thenReturn(
                 "Previous names can be no longer than 160 characters");
 
@@ -476,7 +474,7 @@ class OfficerAppointmnetValidatorTest {
         when(dto.getLastName()).thenReturn("Smith");
         when(dto.getMiddleNames()).thenReturn("Doe");
         when(dto.getTitle()).thenReturn("Mrゃ");
-        when(dto.getFormerNames()).thenReturn(formerNameList);
+        when(dto.getFormerNames()).thenReturn("Anton,Doe");
 
         when(apiEnumerations.getValidation(ValidationEnum.TITLE_CHARACTERS)).thenReturn(
                 "Title must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes");
@@ -492,16 +490,13 @@ class OfficerAppointmnetValidatorTest {
 
     @Test
     void validateFormerNameCharacters() {
-        FormerNameDto formerNames = new FormerNameDto("Jamesゃ","Francis");
-        List<FormerNameDto> formerNameList = new ArrayList<>(1);
-        formerNameList.add(formerNames);
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
         when(transaction.getId()).thenReturn(TRANS_ID);
         when(dto.getFirstName()).thenReturn("John");
         when(dto.getLastName()).thenReturn("Smith");
         when(dto.getMiddleNames()).thenReturn("Doe");
         when(dto.getTitle()).thenReturn("Mr");
-        when(dto.getFormerNames()).thenReturn(formerNameList);
+        when(dto.getFormerNames()).thenReturn("Anton,Doeゃ");
         when(apiEnumerations.getValidation(ValidationEnum.FORMER_NAMES_CHARACTERS)).thenReturn(
                 "Previous name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes");
 
@@ -512,30 +507,5 @@ class OfficerAppointmnetValidatorTest {
                 .hasSize(1)
                 .extracting(ApiError::getError)
                 .contains("Previous name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes");
-
-        formerNames = new FormerNameDto("James","Francisゃ");
-        formerNameList = new ArrayList<>(1);
-        formerNameList.add(formerNames);
-
-        apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
-                PASSTHROUGH_HEADER);
-        assertThat(apiErrors.getErrors())
-                .as("An error should be produced when former names surname contains illegal characters")
-                .hasSize(1)
-                .extracting(ApiError::getError)
-                .contains("Previous name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes");
-
-        formerNames = new FormerNameDto("Jamesゃ","Francisゃ");
-        formerNameList = new ArrayList<>(1);
-        formerNameList.add(formerNames);
-
-        apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
-                PASSTHROUGH_HEADER);
-        assertThat(apiErrors.getErrors())
-                .as("An error should be produced when both forenames and surname contains illegal characters")
-                .hasSize(1)
-                .extracting(ApiError::getError)
-                .contains("Previous name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes");
     }
-
 }


### PR DESCRIPTION
Context

We have currently developed the previous name using a list of DTO objects. However, we need to save the previous names as a string so when the user calls back the name it appears how they have entered it. 

Acceptance Criteria 

AC1: When a software filer submits a previous name it must be saved in the Mongo DB as a string 

AC2: When a software filer submits a previous name it must be a single string in the JSON, rather than a list of objects