### PR TITLE
DACT-739 Updated postcode validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/enumerations/ValidationEnum.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/enumerations/ValidationEnum.java
@@ -64,7 +64,6 @@ public enum ValidationEnum {
     POSTAL_CODE_BLANK("postal-code-blank"),
     POSTAL_CODE_CHARACTERS("postal-code-characters"),
     POSTAL_CODE_LENGTH("postal-code-length"),
-    POSTAL_CODE_WITHOUT_COUNTRY("postal-code-without-country"),
     ADDRESS_LINE_TWO_CHARACTERS("address-line-two-characters"),
     ADDRESS_LINE_TWO_LENGTH("address-line-two-length"),
     REGION_CHARACTERS("region-characters"),

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -441,10 +441,6 @@ public class OfficerAppointmentValidator extends OfficerValidator {
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK));
             return;
         }
-        if((country == null || country.isBlank()) && !(postalCode == null || postalCode.isBlank())){
-            createValidationError(request, errorList,apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_WITHOUT_COUNTRY));
-            return;
-        }
         if(postalCode != null && !postalCode.isBlank()){
             if (!validateDtoFieldLength(postalCode, 20)){
                 createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_LENGTH));

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -326,6 +326,7 @@ public class OfficerAppointmentValidator extends OfficerValidator {
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.PREMISES_BLANK));
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.ADDRESS_LINE_ONE_BLANK));
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.LOCALITY_BLANK));
+            createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK));
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK));
         }
     }
@@ -349,6 +350,7 @@ public class OfficerAppointmentValidator extends OfficerValidator {
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.PREMISES_BLANK));
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.ADDRESS_LINE_ONE_BLANK));
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.LOCALITY_BLANK));
+            createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK));
             createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK));
         }
     }
@@ -435,12 +437,12 @@ public class OfficerAppointmentValidator extends OfficerValidator {
     }
 
     private void validatePostalCode(HttpServletRequest request, List<ApiError> errorList,String postalCode, String country) {
-        if((country == null || country.isBlank()) && !(postalCode == null || postalCode.isBlank())){
-            createValidationError(request, errorList,apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_WITHOUT_COUNTRY));
+        if((country == null || country.isBlank() || ukCountryList.contains(country)) && (postalCode == null || postalCode.isBlank())) {
+            createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK));
             return;
         }
-        if((country != null && ukCountryList.contains(country)) && (postalCode == null || postalCode.isBlank())){
-            createValidationError(request, errorList, apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK));
+        if((country == null || country.isBlank()) && !(postalCode == null || postalCode.isBlank())){
+            createValidationError(request, errorList,apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_WITHOUT_COUNTRY));
             return;
         }
         if(postalCode != null && !postalCode.isBlank()){

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
@@ -1812,6 +1812,40 @@ class OfficerAppointmentValidatorTest {
     }
 
     @Test
+    void validationWhenCorrespondenceAddressMandatoryFieldsAreBlank() {
+        setupDefaultParamaters();
+        when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressOutOfUK)
+                .premises("")
+                .addressLine1("")
+                .locality("")
+                .country("")
+                .postalCode("")
+                .build());
+        when(apiEnumerations.getValidation(ValidationEnum.PREMISES_BLANK)).thenReturn(
+                "Enter a property name or number");
+        when(apiEnumerations.getValidation(ValidationEnum.ADDRESS_LINE_ONE_BLANK)).thenReturn(
+                "Enter an address");
+        when(apiEnumerations.getValidation(ValidationEnum.LOCALITY_BLANK)).thenReturn(
+                "Enter a city or town");
+        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK)).thenReturn(
+                "Enter a postcode or ZIP");
+        when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
+                "Enter a country");
+
+        final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
+                PASSTHROUGH_HEADER);
+        assertThat(apiErrors.getErrors())
+                .as("Errors for mandatory fields should be produced when correspondence address is missing")
+                .hasSize(5)
+                .extracting(ApiError::getError)
+                .contains("Enter a property name or number")
+                .contains("Enter an address")
+                .contains("Enter a city or town")
+                .contains("Enter a postcode or ZIP")
+                .contains("Enter a country");
+    }
+
+    @Test
     void validationWhenCorrespondenceAddressInUKWithNullPostcode() {
         setupDefaultParamaters();
         when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressInUK).postalCode(null).build());

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
@@ -2031,7 +2031,7 @@ class OfficerAppointmentValidatorTest {
     void validationWhenCorrespondenceCountryIsBlankButValidPostcode() {
         setupDefaultParamaters();
         when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressInUK)
-                .country(null)
+                .country("")
                 .build());
 
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
@@ -1538,8 +1538,6 @@ class OfficerAppointmentValidatorTest {
         when(dto.getAppointedOn()).thenReturn(LocalDate.of(2023, 5, 14));
         when(dto.getResidentialAddress()).thenReturn(AddressDto.builder(validResidentialAddress).country(null).postalCode("11111").build());
         when(dto.getServiceAddress()).thenReturn(validCorrespondenceAddressInUK);
-        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_WITHOUT_COUNTRY)).thenReturn(
-                "Select a country from the list before entering a postcode");
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
                 "Select a country from the list");
 
@@ -1547,10 +1545,9 @@ class OfficerAppointmentValidatorTest {
                 PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("An error should be produced when a postcode is submitted without a country")
-                .hasSize(2)
+                .hasSize(1)
                 .extracting(ApiError::getError)
-                .contains("Select a country from the list before entering a postcode")
-                .contains("Select a country from the list");;
+                .contains("Select a country from the list");
     }
 
     void validateWhenMissingAppointmentDate() {
@@ -1877,8 +1874,6 @@ class OfficerAppointmentValidatorTest {
     void validateWhenCorrespondencePostalCodeNoCountry() {
         setupDefaultParamaters();
         when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressOutOfUK).country(null).postalCode("123456").build());
-        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_WITHOUT_COUNTRY)).thenReturn(
-                "Select a country from the list before entering a postcode");
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
                 "Select a country from the list");
 
@@ -1886,10 +1881,9 @@ class OfficerAppointmentValidatorTest {
                 PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("An error should be produced when a postcode is submitted without a country")
-                .hasSize(2)
+                .hasSize(1)
                 .extracting(ApiError::getError)
-                .contains("Select a country from the list before entering a postcode")
-                .contains("Select a country from the list");;
+                .contains("Select a country from the list");
     }
 
     @Test
@@ -2022,18 +2016,15 @@ class OfficerAppointmentValidatorTest {
                 .country(null)
                 .build());
 
-        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_WITHOUT_COUNTRY)).thenReturn(
-                "Select a country from the list before entering a postcode");
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
                 "Select a country from the list");
         final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
                 PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("Errors for mandatory fields should be produced when correspondence address is missing")
-                .hasSize(2)
+                .hasSize(1)
                 .extracting(ApiError::getError)
-                .contains("Select a country from the list before entering a postcode")
-                .contains("Select a country from the list");;
+                .contains("Select a country from the list");
     }
 
     @Test
@@ -2043,18 +2034,15 @@ class OfficerAppointmentValidatorTest {
                 .country(null)
                 .build());
 
-        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_WITHOUT_COUNTRY)).thenReturn(
-                "Select a country from the list before entering a postcode");
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
                 "Select a country from the list");
         final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
                 PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("Errors for mandatory fields should be produced when correspondence address is missing")
-                .hasSize(2)
+                .hasSize(1)
                 .extracting(ApiError::getError)
-                .contains("Select a country from the list before entering a postcode")
-                .contains("Select a country from the list");;
+                .contains("Select a country from the list");
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
@@ -2027,22 +2027,4 @@ class OfficerAppointmentValidatorTest {
                 .contains("Select a country from the list");
     }
 
-    @Test
-    void validationWhenCorrespondenceCountryIsBlankButValidPostcode() {
-        setupDefaultParamaters();
-        when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressInUK)
-                .country("")
-                .build());
-
-        when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
-                "Select a country from the list");
-        final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
-                PASSTHROUGH_HEADER);
-        assertThat(apiErrors.getErrors())
-                .as("Errors for mandatory fields should be produced when correspondence address is missing")
-                .hasSize(1)
-                .extracting(ApiError::getError)
-                .contains("Select a country from the list");
-    }
-
 }

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
@@ -2016,7 +2016,28 @@ class OfficerAppointmentValidatorTest {
     }
 
     @Test
-    void validationWhenCorrespondenceNoCountryValidPostcode() {
+    void validationWhenCorrespondenceCountryIsNullButValidPostcode() {
+        setupDefaultParamaters();
+        when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressInUK)
+                .country(null)
+                .build());
+
+        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_WITHOUT_COUNTRY)).thenReturn(
+                "Select a country from the list before entering a postcode");
+        when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
+                "Select a country from the list");
+        final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
+                PASSTHROUGH_HEADER);
+        assertThat(apiErrors.getErrors())
+                .as("Errors for mandatory fields should be produced when correspondence address is missing")
+                .hasSize(2)
+                .extracting(ApiError::getError)
+                .contains("Select a country from the list before entering a postcode")
+                .contains("Select a country from the list");;
+    }
+
+    @Test
+    void validationWhenCorrespondenceCountryIsBlankButValidPostcode() {
         setupDefaultParamaters();
         when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressInUK)
                 .country(null)

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
@@ -1033,6 +1033,8 @@ class OfficerAppointmentValidatorTest {
                 "Enter an address");
         when(apiEnumerations.getValidation(ValidationEnum.LOCALITY_BLANK)).thenReturn(
                 "Enter a city or town");
+        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK)).thenReturn(
+                "Enter a postcode or ZIP");
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
                 "Enter a country");
 
@@ -1040,11 +1042,12 @@ class OfficerAppointmentValidatorTest {
                 PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("Errors for mandatory fields should be produced when residential address is missing")
-                .hasSize(4)
+                .hasSize(5)
                 .extracting(ApiError::getError)
                 .contains("Enter a property name or number")
                 .contains("Enter an address")
                 .contains("Enter a city or town")
+                .contains("Enter a postcode or ZIP")
                 .contains("Enter a country");
     }
 
@@ -1383,15 +1386,17 @@ class OfficerAppointmentValidatorTest {
         when(dto.getAppointedOn()).thenReturn(LocalDate.of(2023, 5, 14));
         when(dto.getResidentialAddress()).thenReturn(AddressDto.builder(validResidentialAddress).country(null).postalCode(null).build());
         when(dto.getServiceAddress()).thenReturn(validCorrespondenceAddressInUK);
+        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK)).thenReturn(
+                "Enter a postcode or ZIP");
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
                 "Enter a country");
-
         final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
                 PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("An error should be produced when country is blank")
-                .hasSize(1)
+                .hasSize(2)
                 .extracting(ApiError::getError)
+                .contains("Enter a postcode or ZIP")
                 .contains("Enter a country");
     }
 
@@ -1719,6 +1724,19 @@ class OfficerAppointmentValidatorTest {
                 .contains("You can only appoint a person as a director if they are under 110 years old");
     }
 
+    @Test
+    void validationWhenResidentialAddressIsNonUKWithNullPostcode() {
+        setupDefaultParamaters();
+        when(dto.getResidentialAddress()).thenReturn(AddressDto.builder(validResidentialAddress).postalCode(null).build());
+        when(dto.getServiceAddress()).thenReturn(validCorrespondenceAddressInUK);
+        final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
+                PASSTHROUGH_HEADER);
+        //there should NOT be a validation error
+        assertThat(apiErrors.getErrors())
+                .as("An error should not be produced when postal code is blank for a non UK country")
+                .hasSize(0);
+    }
+
     //unit tests validating the corresponding address for the Officer Filing DTO.
     private void setupDefaultParamaters() {
         when(transaction.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
@@ -1743,16 +1761,19 @@ class OfficerAppointmentValidatorTest {
                 "Enter a city or town");
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
                 "Enter a country");
+        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK)).thenReturn(
+                "Enter a postcode or ZIP");
 
         final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
                 PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("Errors for mandatory fields should be produced when correspondence address is missing")
-                .hasSize(4)
+                .hasSize(5)
                 .extracting(ApiError::getError)
                 .contains("Enter a property name or number")
                 .contains("Enter an address")
                 .contains("Enter a city or town")
+                .contains("Enter a postcode or ZIP")
                 .contains("Enter a country");
     }
 
@@ -1764,6 +1785,7 @@ class OfficerAppointmentValidatorTest {
                 .addressLine1(null)
                 .locality(null)
                 .country(null)
+                .postalCode(null)
                 .build());
         when(apiEnumerations.getValidation(ValidationEnum.PREMISES_BLANK)).thenReturn(
                 "Enter a property name or number");
@@ -1771,6 +1793,8 @@ class OfficerAppointmentValidatorTest {
                 "Enter an address");
         when(apiEnumerations.getValidation(ValidationEnum.LOCALITY_BLANK)).thenReturn(
                 "Enter a city or town");
+        when(apiEnumerations.getValidation(ValidationEnum.POSTAL_CODE_BLANK)).thenReturn(
+                "Enter a postcode or ZIP");
         when(apiEnumerations.getValidation(ValidationEnum.COUNTRY_BLANK)).thenReturn(
                 "Enter a country");
 
@@ -1778,11 +1802,12 @@ class OfficerAppointmentValidatorTest {
                 PASSTHROUGH_HEADER);
         assertThat(apiErrors.getErrors())
                 .as("Errors for mandatory fields should be produced when correspondence address is missing")
-                .hasSize(4)
+                .hasSize(5)
                 .extracting(ApiError::getError)
                 .contains("Enter a property name or number")
                 .contains("Enter an address")
                 .contains("Enter a city or town")
+                .contains("Enter a postcode or ZIP")
                 .contains("Enter a country");
     }
 
@@ -1800,6 +1825,18 @@ class OfficerAppointmentValidatorTest {
                 .hasSize(1)
                 .extracting(ApiError::getError)
                 .contains("Enter a postcode or ZIP");
+    }
+
+    @Test
+    void validationWhenCorrespondenceAddressIsNonUKWithNullPostcode() {
+        setupDefaultParamaters();
+        when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressOutOfUK).postalCode(null).build());
+        final var apiErrors = officerAppointmentValidator.validate(request, dto, transaction,
+                PASSTHROUGH_HEADER);
+        //there should NOT be a validation error
+        assertThat(apiErrors.getErrors())
+                .as("An error should not be produced when postal code is blank for a non UK country")
+                .hasSize(0);
     }
 
     @Test


### PR DESCRIPTION
AC1 for residential address and correspondence Address
**Postcode is a mandatory field when**

- No country is entered (or no data is entered)
- When a British country, england, scotland etc is entered .

**It only becomes optional when:**
- A non british country is entered.