### PR TITLE
DACT-1657: Skip address validation if sameAs flags are set

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -92,10 +92,12 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateAppointmentDate(request, errorList, dto);
         validateProtectedDetails(request, errorList, dto);
         validateConsentToAct(request, errorList, dto);
-        if (dto.getIsHomeAddressSameAsServiceAddress() == null || Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) { //home + correspondance
+
+        if (Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) { //home + correspondance
             validateRequiredResidentialAddressFields(request, errorList, dto); //home
         }
-        if (dto.getIsServiceAddressSameAsRegisteredOfficeAddress() == null || Boolean.FALSE.equals(dto.getIsServiceAddressSameAsRegisteredOfficeAddress())) { //correspondance + roa
+
+        if (Boolean.FALSE.equals(dto.getIsServiceAddressSameAsRegisteredOfficeAddress())) { //correspondance + roa
             validateCorrespondenceAddressFields(request, errorList, dto); //correspondance
         }
     }
@@ -106,8 +108,8 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateMiddleNames(request, errorList, dto);
         validateFormerNames(request, errorList, dto);
         validateOccupation(request, errorList, dto);
-        if(dto.getResidentialAddress() != null){
-            if(dto.getIsHomeAddressSameAsServiceAddress() == null || Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
+        if(dto.getResidentialAddress() != null) {
+            if(Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
                 validateOptionalResidentialAddressFields(request, errorList, dto); //home
             }
         }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -93,12 +93,12 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateProtectedDetails(request, errorList, dto);
         validateConsentToAct(request, errorList, dto);
 
-        if (Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) { //home + correspondance
-            validateRequiredResidentialAddressFields(request, errorList, dto); //home
+        if (Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
+            validateRequiredResidentialAddressFields(request, errorList, dto);
         }
 
-        if (Boolean.FALSE.equals(dto.getIsServiceAddressSameAsRegisteredOfficeAddress())) { //correspondance + roa
-            validateCorrespondenceAddressFields(request, errorList, dto); //correspondance
+        if (Boolean.FALSE.equals(dto.getIsServiceAddressSameAsRegisteredOfficeAddress())) {
+            validateCorrespondenceAddressFields(request, errorList, dto);
         }
     }
 
@@ -110,7 +110,7 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateOccupation(request, errorList, dto);
         if(dto.getResidentialAddress() != null) {
             if(Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
-                validateOptionalResidentialAddressFields(request, errorList, dto); //home
+                validateOptionalResidentialAddressFields(request, errorList, dto);
             }
         }
         validateAddressesMultipleFlags(request, errorList, dto);

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -108,10 +108,8 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateMiddleNames(request, errorList, dto);
         validateFormerNames(request, errorList, dto);
         validateOccupation(request, errorList, dto);
-        if(dto.getResidentialAddress() != null) {
-            if(Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
-                validateOptionalResidentialAddressFields(request, errorList, dto);
-            }
+        if(dto.getResidentialAddress() != null && Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
+            validateOptionalResidentialAddressFields(request, errorList, dto);
         }
         validateAddressesMultipleFlags(request, errorList, dto);
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -89,11 +89,15 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateNationality2(request, errorList, dto);
         validateNationality3(request, errorList, dto);
         validateNationalityLength(request, errorList, dto);
-        validateRequiredResidentialAddressFields(request, errorList, dto);
-        validateCorrespondenceAddressFields(request, errorList, dto);
         validateAppointmentDate(request, errorList, dto);
         validateProtectedDetails(request, errorList, dto);
         validateConsentToAct(request, errorList, dto);
+        if (dto.getIsHomeAddressSameAsServiceAddress() == null || Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) { //home + correspondance
+            validateRequiredResidentialAddressFields(request, errorList, dto); //home
+        }
+        if (dto.getIsServiceAddressSameAsRegisteredOfficeAddress() == null || Boolean.FALSE.equals(dto.getIsServiceAddressSameAsRegisteredOfficeAddress())) { //correspondance + roa
+            validateCorrespondenceAddressFields(request, errorList, dto); //correspondance
+        }
     }
 
     @Override
@@ -103,7 +107,9 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateFormerNames(request, errorList, dto);
         validateOccupation(request, errorList, dto);
         if(dto.getResidentialAddress() != null){
-            validateOptionalResidentialAddressFields(request, errorList, dto);
+            if(dto.getIsHomeAddressSameAsServiceAddress() == null || Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
+                validateOptionalResidentialAddressFields(request, errorList, dto); //home
+            }
         }
         validateAddressesMultipleFlags(request, errorList, dto);
     }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidator.java
@@ -93,11 +93,11 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateProtectedDetails(request, errorList, dto);
         validateConsentToAct(request, errorList, dto);
 
-        if (Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
+        if (!Boolean.TRUE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
             validateRequiredResidentialAddressFields(request, errorList, dto);
         }
 
-        if (Boolean.FALSE.equals(dto.getIsServiceAddressSameAsRegisteredOfficeAddress())) {
+        if (!Boolean.TRUE.equals(dto.getIsServiceAddressSameAsRegisteredOfficeAddress())) {
             validateCorrespondenceAddressFields(request, errorList, dto);
         }
     }
@@ -108,7 +108,7 @@ public class OfficerAppointmentValidator extends OfficerValidator {
         validateMiddleNames(request, errorList, dto);
         validateFormerNames(request, errorList, dto);
         validateOccupation(request, errorList, dto);
-        if(dto.getResidentialAddress() != null && Boolean.FALSE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
+        if(dto.getResidentialAddress() != null && !Boolean.TRUE.equals(dto.getIsHomeAddressSameAsServiceAddress())) {
             validateOptionalResidentialAddressFields(request, errorList, dto);
         }
         validateAddressesMultipleFlags(request, errorList, dto);

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
@@ -30,7 +30,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class OfficerAppointmentValidatorTest {
@@ -2362,7 +2363,6 @@ class OfficerAppointmentValidatorTest {
     void validationShouldSkipCorrespondenceAddressValidationIfCorrespondenceSameAsROAFlagSet() {
         setupDefaultParamaters();
         when(dto.getResidentialAddress()).thenReturn(validResidentialAddress);
-        lenient().when(dto.getServiceAddress()).thenReturn(AddressDto.builder(validCorrespondenceAddressInUK).postalCode(null).build());
 
         when(dto.getIsServiceAddressSameAsRegisteredOfficeAddress()).thenReturn(true);
         when(dto.getIsHomeAddressSameAsServiceAddress()).thenReturn(false);
@@ -2372,8 +2372,8 @@ class OfficerAppointmentValidatorTest {
         assertThat(apiErrors.getErrors())
                 .as("No errors for an invalid correspondence address when ServiceAddressSameAsROAFlag set")
                 .isEmpty();
+        verify(dto, never()).getServiceAddress();
     }
-
 
     @Test
     void validationWithCaseInsensitivityForResidentialAndCorrespondenceCountry() {

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerAppointmentValidatorTest.java
@@ -2297,6 +2297,7 @@ class OfficerAppointmentValidatorTest {
     @Test
     void validationWhenBothAddressFlagAreNotSentOrNullValues() {
         setupDefaultParamaters();
+        when(dto.getServiceAddress()).thenReturn(validCorrespondenceAddressInUK);
         when(dto.getIsServiceAddressSameAsRegisteredOfficeAddress()).thenReturn(null);
         when(dto.getIsHomeAddressSameAsServiceAddress()).thenReturn(null);
 
@@ -2313,6 +2314,7 @@ class OfficerAppointmentValidatorTest {
     @Test
     void validationWhenOneAddressFlagIsSetAsTrueAndOtherIsNull() {
         setupDefaultParamaters();
+        when(dto.getServiceAddress()).thenReturn(validCorrespondenceAddressInUK);
         when(dto.getIsServiceAddressSameAsRegisteredOfficeAddress()).thenReturn(null);
         when(dto.getIsHomeAddressSameAsServiceAddress()).thenReturn(true);
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/DACT-1657
Skipping duplicate validation checks on linked addresses if SameAs flags are set, as the linked to address will have already been validated.