### PR TITLE
DACT-1639 TM01, AP01, CH01 name formatting fixes in director names.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <!--- CH -->
         <structured-logging.version>1.9.14</structured-logging.version>
-        <private-api-sdk-java.version>2.0.282</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.345</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <api-security-java.version>0.3.10</api-security-java.version>
         <api-helper-java8.version>1.4.7</api-helper-java8.version>

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -226,15 +226,9 @@ public class FilingDataServiceImpl implements FilingDataService {
     void setTm01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData, AppointmentFullRecordAPI companyAppointment) {
         final String formattedTerminationDate = LocalDate.ofInstant(officerFilingData.getResignedOn(), ZoneOffset.UTC).format(formatter);
         filing.setDescriptionIdentifier(TM01_FILING_DESCRIPTION);
-        var title = "";
-        var surname = "";
-        var middleNames = "";
         var officerFilingName = "";
         if (companyAppointment.getSurname() != null) {
-            title = companyAppointment.getTitle() != null ? companyAppointment.getTitle().toUpperCase() + " " : "";
-            surname = companyAppointment.getSurname().toUpperCase();
-            middleNames = companyAppointment.getOtherForenames() != null ? companyAppointment.getOtherForenames().toUpperCase() + " " : "";
-            officerFilingName = title + companyAppointment.getForename().toUpperCase() + " " + middleNames + surname;
+            officerFilingName = getNameFromAppointment(companyAppointment);
         } else {
             // is a corporate director
             officerFilingName = companyAppointment.getName().toUpperCase();
@@ -247,11 +241,9 @@ public class FilingDataServiceImpl implements FilingDataService {
         filing.setDescriptionValues(values);
     }
 
-        void setAp01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData) {
+    void setAp01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData) {
         final String formattedAppointmentDate = LocalDate.ofInstant(officerFilingData.getAppointedOn(), ZoneOffset.UTC).format(formatter);
-        final String title = officerFilingData.getTitle() != null ? officerFilingData.getTitle().toUpperCase() + " " : "";
-        final String middleNames = officerFilingData.getMiddleNames() != null ? officerFilingData.getMiddleNames().toUpperCase() + " " : "";
-        final String officerFilingName = title + officerFilingData.getFirstName().toUpperCase() + " " + middleNames + officerFilingData.getLastName().toUpperCase();
+        final String officerFilingName = getNameFromOfficerFilingData(officerFilingData);
         filing.setDescriptionIdentifier(AP01_FILING_DESCRIPTION);
         filing.setDescription(AP01_FILING_DESCRIPTION.replace("{" + DIRECTOR_NAME + "}", officerFilingName)
                 .replace("{appointment date}", formattedAppointmentDate));
@@ -261,11 +253,9 @@ public class FilingDataServiceImpl implements FilingDataService {
         ));
     }
 
-        void setCh01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData, AppointmentFullRecordAPI appointment) {
+    void setCh01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData, AppointmentFullRecordAPI appointment) {
         final String formattedUpdateDate = LocalDate.ofInstant(officerFilingData.getDirectorsDetailsChangedDate(), ZoneOffset.UTC).format(formatter);
-        final String title = appointment.getTitle() != null ? appointment.getTitle().toUpperCase() + " " : "";
-        final String otherForenames = appointment.getOtherForenames() != null ? appointment.getOtherForenames().toUpperCase() + " " : "";
-        final String officerFilingName = title + appointment.getForename().toUpperCase() + " " + otherForenames + appointment.getSurname().toUpperCase();
+        final String officerFilingName = getNameFromAppointment(appointment);
         filing.setDescriptionIdentifier(CH01_FILING_DESCRIPTION);
         filing.setDescription(CH01_FILING_DESCRIPTION.replace("{" + DIRECTOR_NAME + "}", officerFilingName)
                 .replace("{update date}", formattedUpdateDate));
@@ -273,5 +263,17 @@ public class FilingDataServiceImpl implements FilingDataService {
                 "update date", formattedUpdateDate,
                 DIRECTOR_NAME, officerFilingName
         ));
+    }
+
+    private static String getNameFromOfficerFilingData(OfficerFilingData officerFilingData) {
+        final String title = officerFilingData.getTitle() != null && !officerFilingData.getTitle().isBlank() ? officerFilingData.getTitle().toUpperCase() + " " : "";
+        final String middleNames = officerFilingData.getMiddleNames() != null && !officerFilingData.getMiddleNames().isBlank() ? officerFilingData.getMiddleNames().toUpperCase() + " " : "";
+        return title + officerFilingData.getFirstName().toUpperCase() + " " + middleNames + officerFilingData.getLastName().toUpperCase();
+    }
+
+    private static String getNameFromAppointment(AppointmentFullRecordAPI companyAppointment) {
+        String title = companyAppointment.getTitle() != null && !companyAppointment.getTitle().isBlank() ? companyAppointment.getTitle().toUpperCase() + " " : "";
+        String middleNames = companyAppointment.getOtherForenames() != null && !companyAppointment.getOtherForenames().isBlank() ? companyAppointment.getOtherForenames().toUpperCase() + " " : "";
+        return title + companyAppointment.getForename().toUpperCase() + " " + middleNames + companyAppointment.getSurname().toUpperCase();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -223,19 +223,21 @@ public class FilingDataServiceImpl implements FilingDataService {
         return false;
     }
 
-    private void setTm01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData, AppointmentFullRecordAPI companyAppointment) {
+    void setTm01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData, AppointmentFullRecordAPI companyAppointment) {
         final String formattedTerminationDate = LocalDate.ofInstant(officerFilingData.getResignedOn(), ZoneOffset.UTC).format(formatter);
         filing.setDescriptionIdentifier(TM01_FILING_DESCRIPTION);
+        var title = "";
         var surname = "";
         var middleNames = "";
         var officerFilingName = "";
         if (companyAppointment.getSurname() != null) {
+            title = companyAppointment.getTitle() != null ? companyAppointment.getTitle().toUpperCase() + " " : "";
             surname = companyAppointment.getSurname().toUpperCase();
-            middleNames = companyAppointment.getOtherForenames();
-            officerFilingName = companyAppointment.getForename() + " " + middleNames + " " + surname;
+            middleNames = companyAppointment.getOtherForenames() != null ? companyAppointment.getOtherForenames().toUpperCase() + " " : "";
+            officerFilingName = title + companyAppointment.getForename().toUpperCase() + " " + middleNames + surname;
         } else {
             // is a corporate director
-            officerFilingName = companyAppointment.getName();
+            officerFilingName = companyAppointment.getName().toUpperCase();
         }
         filing.setDescription(TM01_FILING_DESCRIPTION.replace("{" + DIRECTOR_NAME + "}", officerFilingName)
                 .replace("{termination date}", formattedTerminationDate));
@@ -245,9 +247,11 @@ public class FilingDataServiceImpl implements FilingDataService {
         filing.setDescriptionValues(values);
     }
 
-    private void setAp01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData) {
+        void setAp01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData) {
         final String formattedAppointmentDate = LocalDate.ofInstant(officerFilingData.getAppointedOn(), ZoneOffset.UTC).format(formatter);
-        final String officerFilingName = officerFilingData.getFirstName().toUpperCase() + " " + officerFilingData.getMiddleNames().toUpperCase() + " " + officerFilingData.getLastName().toUpperCase();
+        final String title = officerFilingData.getTitle() != null ? officerFilingData.getTitle().toUpperCase() + " " : "";
+        final String middleNames = officerFilingData.getMiddleNames() != null ? officerFilingData.getMiddleNames().toUpperCase() + " " : "";
+        final String officerFilingName = title + officerFilingData.getFirstName().toUpperCase() + " " + middleNames + officerFilingData.getLastName().toUpperCase();
         filing.setDescriptionIdentifier(AP01_FILING_DESCRIPTION);
         filing.setDescription(AP01_FILING_DESCRIPTION.replace("{" + DIRECTOR_NAME + "}", officerFilingName)
                 .replace("{appointment date}", formattedAppointmentDate));
@@ -257,9 +261,11 @@ public class FilingDataServiceImpl implements FilingDataService {
         ));
     }
 
-    private void setCh01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData, AppointmentFullRecordAPI appointment) {
+        void setCh01DescriptionFields(FilingApi filing, OfficerFilingData officerFilingData, AppointmentFullRecordAPI appointment) {
         final String formattedUpdateDate = LocalDate.ofInstant(officerFilingData.getDirectorsDetailsChangedDate(), ZoneOffset.UTC).format(formatter);
-        final String officerFilingName = appointment.getForename().toUpperCase() + " " + appointment.getOtherForenames() + " " + appointment.getSurname().toUpperCase();
+        final String title = appointment.getTitle() != null ? appointment.getTitle().toUpperCase() + " " : "";
+        final String otherForenames = appointment.getOtherForenames() != null ? appointment.getOtherForenames().toUpperCase() + " " : "";
+        final String officerFilingName = title + appointment.getForename().toUpperCase() + " " + otherForenames + appointment.getSurname().toUpperCase();
         filing.setDescriptionIdentifier(CH01_FILING_DESCRIPTION);
         filing.setDescription(CH01_FILING_DESCRIPTION.replace("{" + DIRECTOR_NAME + "}", officerFilingName)
                 .replace("{update date}", formattedUpdateDate));

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImplTest.java
@@ -633,6 +633,34 @@ class FilingDataServiceImplTest {
     }
 
     @Test
+    void testSetTm01DescriptionFieldsWithFirstNameLastNameAndEMPTYTitleWHITESPACEDMiddleName() {
+        // Prepare test data
+        final Instant resignedOn = Instant.parse("2022-10-05T00:00:00Z");
+        final String formattedResignationDate = "5 October 2022";
+        final OfficerFilingData officerFilingData = OfficerFilingData.builder()
+                .resignedOn(resignedOn)
+                .build();
+        final FilingApi filing = new FilingApi();
+
+        // when
+        when(companyAppointment.getTitle()).thenReturn("");
+        when(companyAppointment.getSurname()).thenReturn("Bloggs");
+        when(companyAppointment.getOtherForenames()).thenReturn("  ");
+        when(companyAppointment.getForename()).thenReturn("Joe");
+
+        // under test
+        testService.setTm01DescriptionFields(filing, officerFilingData, companyAppointment);
+
+        // then
+        Map<String, String> expectedValues = new HashMap<>();
+        expectedValues.put("director name", "JOE BLOGGS");
+        expectedValues.put("termination date", formattedResignationDate);
+
+        assertThat(filing.getDescription(), is("(TM01) Termination of appointment of a director. Terminating appointment of JOE BLOGGS on 5 October 2022"));
+        assertThat(expectedValues, is(filing.getDescriptionValues()));
+    }
+
+    @Test
     void setAp01DescriptionFieldsWithFullName() {
         // Prepare test data
         final String formattedAppointmentDate = "1 January 2023";
@@ -664,6 +692,31 @@ class FilingDataServiceImplTest {
                 .appointedOn(Instant.parse("2023-01-01T00:00:00Z"))
                 .firstName("Joe")
                 .lastName("Bloggs")
+                .build();
+        final FilingApi filing = new FilingApi();
+
+        // under test
+        testService.setAp01DescriptionFields(filing, officerFilingData);
+
+        // then
+        Map<String, String> expectedValues = new HashMap<>();
+        expectedValues.put("director name", "JOE BLOGGS");
+        expectedValues.put("appointment date", formattedAppointmentDate);
+        assertThat(filing.getDescription(), is("(AP01) Appointment of a director. Appointment of JOE BLOGGS on 1 January 2023"));
+        assertThat(filing.getDescriptionValues(), is(expectedValues));
+    }
+
+
+    @Test
+    void setAp01DescriptionFieldsWithFistNameLastNameAndEMPTYTitleWHITESPACEDMiddleName() {
+        // Prepare test data
+        final String formattedAppointmentDate = "1 January 2023";
+        final OfficerFilingData officerFilingData = OfficerFilingData.builder()
+                .appointedOn(Instant.parse("2023-01-01T00:00:00Z"))
+                .title("")
+                .firstName("Joe")
+                .lastName("Bloggs")
+                .middleNames("  ")
                 .build();
         final FilingApi filing = new FilingApi();
 
@@ -716,6 +769,32 @@ class FilingDataServiceImplTest {
 
         // when
         when(companyAppointment.getSurname()).thenReturn("Bloggs");
+        when(companyAppointment.getForename()).thenReturn("Joe");
+
+        // under test
+        testService.setCh01DescriptionFields(filing, officerFilingData, companyAppointment);
+
+        // then
+        Map<String, String> expectedValues = new HashMap<>();
+        expectedValues.put("director name", "JOE BLOGGS");
+        expectedValues.put("update date", formattedUpdateDate);
+        assertThat(filing.getDescription(), is("(CH01) Update of a director. Update of JOE BLOGGS on 1 January 2023"));
+        assertThat(filing.getDescriptionValues(), is(expectedValues));
+    }
+
+    @Test
+    void setCh01DescriptionFieldsWithFirstNameLastNameAndEMPTYTitleWHITESPACEDMiddleName() {
+        // Prepare test data
+        final String formattedUpdateDate = "1 January 2023";
+        final OfficerFilingData officerFilingData = OfficerFilingData.builder()
+                .directorsDetailsChangedDate(Instant.parse("2023-01-01T00:00:00Z"))
+                .build();
+        final FilingApi filing = new FilingApi();
+
+        // when
+        when(companyAppointment.getSurname()).thenReturn("");
+        when(companyAppointment.getSurname()).thenReturn("Bloggs");
+        when(companyAppointment.getOtherForenames()).thenReturn("  ");
         when(companyAppointment.getForename()).thenReturn("Joe");
 
         // under test


### PR DESCRIPTION
* Director names should be capitalised.
* Director names should include title and middle name if provided.
* Fix for CH01 director name in email contains null if middle name is absent in the appointment.
* Corporate director name should be capitalised if not already in the appointment.