### PR TITLE
bugfix/DACT-1911 Nationality length check when nationality2 is empty but nationality3 present.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerValidator.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerValidator.java
@@ -333,7 +333,7 @@ public abstract class OfficerValidator {
             .filter(Objects::nonNull)
             .map(s -> s.replace(",", ""))
             .map(String::trim)
-            .filter(s -> StringUtils.isNotEmpty(s))
+            .filter(StringUtils::isNotEmpty)
             .collect(Collectors.joining(","));
        
         if (!validateDtoFieldLength(nationatities, 50)) {

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerValidatorTest.java
@@ -324,6 +324,26 @@ class OfficerValidatorTest {
                 .contains("For technical reasons, we are currently unable to accept dual nationalities with a total of more than 49 characters");
     }
 
+    /**
+     * This test case is failing, in CHIPS we just pass all the nationalities as 1 string with comma seperated value,
+     * with that in mind user can choose to pass nationality 1 and 3 and bypass the rule of 49 characters.
+     * The request can make a way to CHIPS and go to query handling, to avoid we need to fix the scenario where we check 1 and 3 too for 49 characters.
+     */
+    @Test
+    void validateNationality1And3LengthWhen50Exactly() {
+        when(dto.getNationality1()).thenReturn("Abcdefghijklmnopqrstuvwxyz");
+        when(dto.getNationality3()).thenReturn("Abcdefghijklmnopqrstuvwx");
+        when(apiEnumerations.getValidation(ValidationEnum.NATIONALITY_LENGTH49)).thenReturn(
+                "For technical reasons, we are currently unable to accept dual nationalities with a total of more than 49 characters");
+
+        officerValidator.validateNationalityLength(request, apiErrorsList, dto);
+        assertThat(apiErrorsList)
+                .as("An error should be produced when nationality1 and 2 contain more than 49 characters between them")
+                .hasSize(1)
+                .extracting(ApiError::getError)
+                .contains("For technical reasons, we are currently unable to accept dual nationalities with a total of more than 49 characters");
+    }
+
     @Test
     void validateNationality1And2LengthWhen49Exactly() {
         when(dto.getNationality1()).thenReturn("Abcdefghijklmnopqrstuvwxyz");

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/validation/OfficerValidatorTest.java
@@ -324,11 +324,6 @@ class OfficerValidatorTest {
                 .contains("For technical reasons, we are currently unable to accept dual nationalities with a total of more than 49 characters");
     }
 
-    /**
-     * This test case is failing, in CHIPS we just pass all the nationalities as 1 string with comma seperated value,
-     * with that in mind user can choose to pass nationality 1 and 3 and bypass the rule of 49 characters.
-     * The request can make a way to CHIPS and go to query handling, to avoid we need to fix the scenario where we check 1 and 3 too for 49 characters.
-     */
     @Test
     void validateNationality1And3LengthWhen50Exactly() {
         when(dto.getNationality1()).thenReturn("Abcdefghijklmnopqrstuvwxyz");


### PR DESCRIPTION
JIRA bug: https://companieshouse.atlassian.net/browse/DACT-1911
Fix nationality length validation to not assume nationality3 is empty if nationality2 is.