### PR TITLE
ASM-2424 Update application to Spring Boot 4.1.x

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # List of thundercats dev for approvals
-* @companieshouse/team-thundercats
+* @companieshouse/voyager-devs

--- a/pom.xml
+++ b/pom.xml
@@ -45,13 +45,13 @@
         <!-- Source: https://mvnrepository.com/artifact/org.mapstruct/mapstruct -->
         <mapstruct.version>1.6.3</mapstruct.version>
         <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom -->
-        <opentelemetry.version>2.28.1</opentelemetry.version>
+        <opentelemetry.version>2.29.0</opentelemetry.version>
         <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom -->
         <kotlin.version>2.3.21</kotlin.version>
 
         <!--- CH -->
         <structured-logging.version>3.0.57</structured-logging.version>
-        <private-api-sdk-java.version>6.0.24</private-api-sdk-java.version>
+        <private-api-sdk-java.version>6.0.33</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.23</api-sdk-manager-java-library.version>
         <api-security-java.version>2.0.27</api-security-java.version>
         <api-helper-java.version>3.0.4</api-helper-java.version>
@@ -89,15 +89,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-            <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.proto/opentelemetry-proto -->
-            <dependency>
-                <groupId>io.opentelemetry.proto</groupId>
-                <artifactId>opentelemetry-proto</artifactId>
-                <version>1.10.0-alpha</version>
-                <scope>runtime</scope>
-            </dependency>
-
 
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -156,14 +147,6 @@
             <version>${mapstruct.version}</version>
         </dependency>
 
-        <!--  force use of commons-lang3 version 3.18 to avoid vulnerability in 3.17 that is transitive
-         in several CH dependencies.  Can be removed when those are updated -->
-<!--        <dependency>-->
-<!--            <groupId>org.apache.commons</groupId>-->
-<!--            <artifactId>commons-lang3</artifactId>-->
-<!--            <version>3.18.0</version>-->
-<!--        </dependency>-->
-
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
@@ -214,24 +197,6 @@
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
         </dependency>
 
-<!--        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>-->
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
@@ -245,14 +210,6 @@
             <version>${equalsverifier.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- Dev Tools -->
-<!--        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>-->
 
     </dependencies>
 
@@ -339,7 +296,6 @@
                 </executions>
             </plugin>
 
-<!--
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -352,7 +308,7 @@
                             <goal>prepare-agent-integration</goal>
                         </goals>
                         <configuration>
-                            &lt;!&ndash; Sets the path to the file which contains the execution data. &ndash;&gt;
+                            <!-- Sets the path to the file which contains the execution data. -->
                             <destFile>target/jacoco-it.exec</destFile>
                             <propertyName>failsafeArgLine</propertyName>
                         </configuration>
@@ -364,15 +320,14 @@
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            &lt;!&ndash; Sets the path to the file which contains the execution data. &ndash;&gt;
+                            <!-- Sets the path to the file which contains the execution data. -->
                             <dataFile>target/jacoco-it.exec</dataFile>
-                            &lt;!&ndash; Sets the output directory for the code coverage report. &ndash;&gt;
+                            <!-- Sets the output directory for the code coverage report. -->
                             <outputDirectory>${sonar.jacoco.reports}/jacoco-it</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
--->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,164 +3,186 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.12</version>
+        <version>2.1.14</version>
         <relativePath/>
     </parent>
+
     <artifactId>officer-filing-api</artifactId>
     <version>unversioned</version>
     <name>officer-filing-api</name>
     <description>Public API for Officer Filings</description>
+
     <properties>
         <java.version>21</java.version>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
+
         <!-- Spring -->
-        <spring-boot-dependencies.version>3.5.14</spring-boot-dependencies.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
+
         <!-- Maven -->
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
-        <!-- Docker -->
-        <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
+
+        <!-- Plugin Versions -->
+        <!-- Source: https://mvnrepository.com/artifact/com.google.cloud.tools/jib-maven-plugin -->
+        <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-failsafe-plugin -->
+        <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
+
+        <!-- Source: https://mvnrepository.com/artifact/org.mockito/mockito-inline -->
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <equalsverifier.version>4.0.3</equalsverifier.version>
+        <!-- Source: https://mvnrepository.com/artifact/nl.jqno.equalsverifier/equalsverifier -->
+        <equalsverifier.version>4.5</equalsverifier.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.mapstruct/mapstruct -->
         <mapstruct.version>1.6.3</mapstruct.version>
-        <opentelemetry-instrumentation-bom.version>2.24.0</opentelemetry-instrumentation-bom.version>
+        <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom -->
+        <opentelemetry.version>2.28.1</opentelemetry.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom -->
+        <kotlin.version>2.3.21</kotlin.version>
+
         <!--- CH -->
-        <structured-logging.version>3.0.51</structured-logging.version>
-        <private-api-sdk-java.version>4.0.476</private-api-sdk-java.version>
-        <api-sdk-manager-java-library.version>3.0.16</api-sdk-manager-java-library.version>
-        <api-security-java.version>2.0.24</api-security-java.version>
-        <api-helper-java.version>3.0.3</api-helper-java.version>
+        <structured-logging.version>3.0.57</structured-logging.version>
+        <private-api-sdk-java.version>6.0.24</private-api-sdk-java.version>
+        <api-sdk-manager-java-library.version>3.0.23</api-sdk-manager-java-library.version>
+        <api-security-java.version>2.0.27</api-security-java.version>
+        <api-helper-java.version>3.0.4</api-helper-java.version>
+
         <!--sonar configuration-->
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml,
-            ${project.build.directory}/site/jacoco-it/jacoco.xml
-        </sonar.coverage.jacoco.xmlReportPaths>
-        <sonar.jacoco.reports>${project.build.directory}/site</sonar.jacoco.reports>
-        <sonar.jacoco.reportPath>target/site/jacoco/jacoco.xml</sonar.jacoco.reportPath>
-        <sonar.java.binaries>
-            ${project.basedir}/target
-        </sonar.java.binaries>
-        <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
+        <!--suppress UnresolvedMavenProperty -->
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.projectKey>uk.gov.companieshouse:officer-filing-api</sonar.projectKey>
         <sonar.projectName>officer-filing-api</sonar.projectName>
 
     </properties>
+
     <dependencyManagement>
         <dependencies>
+
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-bom</artifactId>
-                <version>${opentelemetry-instrumentation-bom.version}</version>
+                <version>${opentelemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot-dependencies.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- PINNED: CVE-2025-68161 workaround in spring-boot-starter-actuator@3.5.10 transitive dependency log4j-api@2.24.3 -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.25.4</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-                <version>2.25.4</version>
-            </dependency>
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-api</artifactId>
-                <version>1.81.0</version>
-            </dependency>
+
              <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-context</artifactId>
                 <version>1.81.0</version>
             </dependency>
-             <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.55</version>
+
+            <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
-             <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>10.1.55</version>
+
+            <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.proto/opentelemetry-proto -->
+            <dependency>
+                <groupId>io.opentelemetry.proto</groupId>
+                <artifactId>opentelemetry-proto</artifactId>
+                <version>1.10.0-alpha</version>
+                <scope>runtime</scope>
             </dependency>
+
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
-        <!-- Pinning version to address CVE-2020-29582(5.3) in kotlin-stdlib:jar:1.9.25
-             pulled transitively by opentelemetry-spring-boot-starter:jar:2.23.0 -->
+
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-            <version>2.2.21</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-opentelemetry</artifactId>
         </dependency>
+
+        <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-logback-appender-1.0 -->
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-spring-boot-starter</artifactId>
+            <artifactId>opentelemetry-logback-appender-1.0</artifactId>
+            <version>${opentelemetry.version}-alpha</version>
+            <scope>compile</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
         </dependency>
+
         <!--  force use of commons-lang3 version 3.18 to avoid vulnerability in 3.17 that is transitive
          in several CH dependencies.  Can be removed when those are updated -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.apache.commons</groupId>-->
+<!--            <artifactId>commons-lang3</artifactId>-->
+<!--            <version>3.18.0</version>-->
+<!--        </dependency>-->
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
         </dependency>
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-security-java</artifactId>
             <version>${api-security-java.version}</version>
         </dependency>
+
         <!-- SDKs -->
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>private-api-sdk-java</artifactId>
             <version>${private-api-sdk-java.version}</version>
         </dependency>
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-manager-java-library</artifactId>
@@ -173,6 +195,7 @@
             </exclusions>
             <version>${api-sdk-manager-java-library.version}</version>
         </dependency>
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-helper-java</artifactId>
@@ -185,44 +208,57 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+        </dependency>
+
+<!--        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>
-        </dependency>
+        </dependency>-->
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito-inline.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
             <version>${equalsverifier.version}</version>
             <scope>test</scope>
         </dependency>
+
         <!-- Dev Tools -->
-        <dependency>
+<!--        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
-        </dependency>
+        </dependency>-->
+
     </dependencies>
 
     <build>
         <plugins>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -241,10 +277,11 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot-dependencies.version}</version>
+                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -253,6 +290,7 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
@@ -269,6 +307,7 @@
                     </container>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -277,6 +316,7 @@
                     <skipTests>${skip.unit.tests}</skipTests>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -298,6 +338,8 @@
                     </execution>
                 </executions>
             </plugin>
+
+<!--
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -310,7 +352,7 @@
                             <goal>prepare-agent-integration</goal>
                         </goals>
                         <configuration>
-                            <!-- Sets the path to the file which contains the execution data. -->
+                            &lt;!&ndash; Sets the path to the file which contains the execution data. &ndash;&gt;
                             <destFile>target/jacoco-it.exec</destFile>
                             <propertyName>failsafeArgLine</propertyName>
                         </configuration>
@@ -322,14 +364,15 @@
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            <!-- Sets the path to the file which contains the execution data. -->
+                            &lt;!&ndash; Sets the path to the file which contains the execution data. &ndash;&gt;
                             <dataFile>target/jacoco-it.exec</dataFile>
-                            <!-- Sets the output directory for the code coverage report. -->
+                            &lt;!&ndash; Sets the output directory for the code coverage report. &ndash;&gt;
                             <outputDirectory>${sonar.jacoco.reports}/jacoco-it</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+-->
         </plugins>
     </build>
 

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandler.java
@@ -1,15 +1,14 @@
 package uk.gov.companieshouse.officerfiling.api.error;
 
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
 import jakarta.servlet.http.HttpServletRequest;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
@@ -17,8 +16,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,6 +24,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.databind.exc.MismatchedInputException;
 import uk.gov.companieshouse.api.error.ApiError;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
@@ -63,16 +63,16 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         final var baseMessage = "JSON parse error: ";
         final ApiError error;
 
-        if (ex.getCause() instanceof JsonProcessingException jsonProcessingException) {
-            final var msg = baseMessage + jsonProcessingException.getMessage();
-            final var location = jsonProcessingException.getLocation();
+        if (ex.getCause() instanceof JacksonException jacksonException) {
+            final var msg = baseMessage + jacksonException.getMessage();
+            final var location = jacksonException.getLocation();
             var jsonPath = "$";
 
-            if (jsonProcessingException instanceof MismatchedInputException) {
+            if (jacksonException instanceof MismatchedInputException) {
                 final var fieldNameOpt = ((MismatchedInputException) ex.getCause()).getPath()
                         .stream()
                         .findFirst()
-                        .map(JsonMappingException.Reference::getFieldName);
+                        .map(JacksonException.Reference::getPropertyName);
                 jsonPath += fieldNameOpt.map(f -> ".." + f).orElse("");
             }
 
@@ -164,7 +164,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         return new ApiErrors(errorList);
     }
 
-    private static void addLocationInfo(final ApiError error, final JsonLocation location) {
+    private static void addLocationInfo(final ApiError error, final TokenStreamLocation location) {
         error.addErrorValue("offset", location.offsetDescription());
         error.addErrorValue("line", String.valueOf(location.getLineNr()));
         error.addErrorValue("column", String.valueOf(location.getColumnNr()));

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/AddressDto.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/AddressDto.java
@@ -1,8 +1,9 @@
 package uk.gov.companieshouse.officerfiling.api.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/OfficerFilingDto.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/model/dto/OfficerFilingDto.java
@@ -1,10 +1,8 @@
 package uk.gov.companieshouse.officerfiling.api.model.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.springframework.validation.annotation.Validated;
-import uk.gov.companieshouse.JsonBooleanDeserializer;
-
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -229,8 +227,7 @@ public class OfficerFilingDto {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof OfficerFilingDto)) return false;
-        OfficerFilingDto that = (OfficerFilingDto) o;
+        if (!(o instanceof OfficerFilingDto that)) return false;
         return Objects.equals(getServiceAddress(), that.getServiceAddress()) && Objects.equals(getServiceAddressBackLink(), that.getServiceAddressBackLink()) && Objects.equals(getServiceManualAddressBackLink(), that.getServiceManualAddressBackLink()) && Objects.equals(getProtectedDetailsBackLink(), that.getProtectedDetailsBackLink()) && Objects.equals(getIsServiceAddressSameAsRegisteredOfficeAddress(), that.getIsServiceAddressSameAsRegisteredOfficeAddress()) && Objects.equals(getAppointedOn(), that.getAppointedOn()) && Objects.equals(getCountryOfResidence(), that.getCountryOfResidence()) && Objects.equals(getDateOfBirth(), that.getDateOfBirth()) && Objects.equals(getFormerNames(), that.getFormerNames()) && Objects.equals(getIdentification(), that.getIdentification()) && Objects.equals(getName(), that.getName()) && Objects.equals(getTitle(), that.getTitle()) && Objects.equals(getFirstName(), that.getFirstName()) && Objects.equals(getMiddleNames(), that.getMiddleNames()) && Objects.equals(getLastName(), that.getLastName()) && Objects.equals(getNationality1(), that.getNationality1()) && Objects.equals(getNationality2(), that.getNationality2()) && Objects.equals(getNationality3(), that.getNationality3()) && Objects.equals(getOccupation(), that.getOccupation()) && Objects.equals(getReferenceEtag(), that.getReferenceEtag()) && Objects.equals(getReferenceAppointmentId(), that.getReferenceAppointmentId()) && Objects.equals(getReferenceOfficerListEtag(), that.getReferenceOfficerListEtag()) && Objects.equals(getResignedOn(), that.getResignedOn()) && Objects.equals(getResidentialAddress(), that.getResidentialAddress()) && Objects.equals(getResidentialAddressBackLink(), that.getResidentialAddressBackLink()) && Objects.equals(getResidentialManualAddressBackLink(), that.getResidentialManualAddressBackLink()) && Objects.equals(getIsHomeAddressSameAsServiceAddress(), that.getIsHomeAddressSameAsServiceAddress()) && Objects.equals(getNationality2Link(), that.getNationality2Link()) && Objects.equals(getNationality3Link(), that.getNationality3Link()) && Objects.equals(getDirectorAppliedToProtectDetails(), that.getDirectorAppliedToProtectDetails()) && Objects.equals(getConsentToAct(), that.getConsentToAct()) && Objects.equals(getCheckYourAnswersLink(), that.getCheckYourAnswersLink()) && Objects.equals(getDirectorResidentialAddressChoice(), that.getDirectorResidentialAddressChoice()) && Objects.equals(getDirectorServiceAddressChoice(), that.getDirectorServiceAddressChoice()) && Objects.equals(getNameHasBeenUpdated(), that.getNameHasBeenUpdated()) && Objects.equals(getNationalityHasBeenUpdated(), that.getNationalityHasBeenUpdated()) && Objects.equals(getOccupationHasBeenUpdated(), that.getOccupationHasBeenUpdated()) && Objects.equals(getServiceAddressHasBeenUpdated(), that.getServiceAddressHasBeenUpdated()) && Objects.equals(getResidentialAddressHasBeenUpdated(), that.getResidentialAddressHasBeenUpdated()) && Objects.equals(getDirectorsDetailsChangedDate(), that.getDirectorsDetailsChangedDate()) && Objects.equals(getDescription(), that.getDescription());
     }
 
@@ -326,7 +323,6 @@ public class OfficerFilingDto {
             return this;
         }
 
-        @JsonDeserialize(using = JsonBooleanDeserializer.class)
         public Builder isServiceAddressSameAsRegisteredOfficeAddress(final Boolean value) {
 
             buildSteps.add(data -> data.isServiceAddressSameAsRegisteredOfficeAddress = value);
@@ -476,7 +472,6 @@ public class OfficerFilingDto {
             return this;
         }
 
-        @JsonDeserialize(using = JsonBooleanDeserializer.class)
         public Builder isHomeAddressSameAsServiceAddress(final Boolean value) {
 
             buildSteps.add(data -> data.isHomeAddressSameAsServiceAddress = value);
@@ -493,13 +488,11 @@ public class OfficerFilingDto {
             return this;
         }
 
-        @JsonDeserialize(using = JsonBooleanDeserializer.class)
         public Builder directorAppliedToProtectDetails(final Boolean value) {
             buildSteps.add(data -> data.directorAppliedToProtectDetails = value);
             return this;
         }
 
-        @JsonDeserialize(using = JsonBooleanDeserializer.class)
         public Builder consentToAct(final Boolean value) {
             buildSteps.add(data -> data.consentToAct = value);
             return this;

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/FilingDataServiceImpl.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.officerfiling.api.service;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.PropertyNamingStrategies;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentFullRecordAPI;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -151,7 +151,9 @@ public class FilingDataServiceImpl implements FilingDataService {
                 .build();
 
         var filingData = filingAPIMapper.map(enhancedOfficerFiling);
-        var dataMap = MapHelper.convertObject(filingData, PropertyNamingStrategies.SNAKE_CASE);
+        var dataMap = MapHelper.convertObject(
+                filingData,
+                PropertyNamingStrategies.SNAKE_CASE);
         logger.debugContext(transactionId, "Created appointment filing data for submission", new LogHelper.Builder(transaction)
                 .withFilingId(filingId)
                 .build());
@@ -183,7 +185,9 @@ public class FilingDataServiceImpl implements FilingDataService {
                 .data(dataBuilder.build())
                 .build();
         var filingData = filingAPIMapper.map(enhancedOfficerFiling);
-        var dataMap = MapHelper.convertObject(filingData, PropertyNamingStrategies.SNAKE_CASE);
+        var dataMap = MapHelper.convertObject(
+                filingData,
+                PropertyNamingStrategies.SNAKE_CASE);
         logger.debugContext(transactionId, "Created update filing data for submission", new LogHelper.Builder(transaction)
                 .withFilingId(filingId)
                 .build());

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerFilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerFilingServiceImpl.java
@@ -1,14 +1,15 @@
 package uk.gov.companieshouse.officerfiling.api.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.OfficerFilingServiceException;
@@ -78,12 +79,12 @@ public class OfficerFilingServiceImpl implements OfficerFilingService {
         extractFields(original, fieldMap);
         extractFields(patch, fieldMap);
         // JavaTimeModule handles Instant serialisation
-        var mapper = JsonMapper.builder().addModule(new JavaTimeModule()).build();
+        var mapper = JsonMapper.builder().enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID).build();
 
         try {
             var updatedFilingJson = new ObjectMapper().writeValueAsString(fieldMap);
             mergedFiling = mapper.readerFor(OfficerFiling.class).readValue(updatedFilingJson);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new OfficerFilingServiceException("Failed to patch an officer filing for company "
                     + transaction.getCompanyNumber(), e);
         }

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerFilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/service/OfficerFilingServiceImpl.java
@@ -78,7 +78,6 @@ public class OfficerFilingServiceImpl implements OfficerFilingService {
         // Original values
         extractFields(original, fieldMap);
         extractFields(patch, fieldMap);
-        // JavaTimeModule handles Instant serialisation
         var mapper = JsonMapper.builder().enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID).build();
 
         try {

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/utils/MapHelper.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/utils/MapHelper.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.officerfiling.api.utils;
 
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.PropertyNamingStrategy;
 import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.json.JsonMapper;
@@ -13,11 +12,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public final class MapHelper {
 
-    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
-    };
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
-    private static final Map<PropertyNamingStrategy, ObjectMapper> MAPPER_CACHE =
-            new ConcurrentHashMap<>();
+    private static final Map<PropertyNamingStrategy, ObjectMapper> MAPPER_CACHE = new ConcurrentHashMap<>();
 
     private MapHelper() {
         // intentionally blank

--- a/src/main/java/uk/gov/companieshouse/officerfiling/api/utils/MapHelper.java
+++ b/src/main/java/uk/gov/companieshouse/officerfiling/api/utils/MapHelper.java
@@ -1,37 +1,46 @@
 package uk.gov.companieshouse.officerfiling.api.utils;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.PropertyNamingStrategy;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class MapHelper {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
+    };
+
+    private static final Map<PropertyNamingStrategy, ObjectMapper> MAPPER_CACHE =
+            new ConcurrentHashMap<>();
 
     private MapHelper() {
         // intentionally blank
     }
 
-    private static ObjectMapper mapper = null;
-
     /**
      * Convert an Object into a Key/Value property map.
      *
      * @param obj the Object
+     * @param strategy property naming strategy used when serializing object fields
      * @return a Map of property values
      */
     public static Map<String, Object> convertObject(Object obj, PropertyNamingStrategy strategy) {
-        if (mapper == null) {
-            mapper = new ObjectMapper().setPropertyNamingStrategy(
-                    strategy);
-            mapper.registerModule(new JavaTimeModule());
-        }
-        if (mapper.getPropertyNamingStrategy() != strategy){
-            mapper.setPropertyNamingStrategy(strategy);
-        }
+        Objects.requireNonNull(strategy, "strategy must not be null");
 
-        return mapper.convertValue(obj, new TypeReference<>() {
-        });
+        final ObjectMapper mapper = MAPPER_CACHE.computeIfAbsent(strategy, MapHelper::buildMapper);
+        return mapper.convertValue(obj, MAP_TYPE);
     }
 
+    private static ObjectMapper buildMapper(PropertyNamingStrategy strategy) {
+        return JsonMapper.builder()
+                .propertyNamingStrategy(strategy)
+                .enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID)
+                .build();
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,17 @@
 # Spring Actuator
-management.endpoints.enabled-by-default=${MANAGEMENT_ENDPOINTS_ENABLED_BY_DEFAULT}
-management.endpoint.health.enabled=${MANAGEMENT_ENDPOINT_HEALTH_ENABLED}
+management.opentelemetry.enabled=${OTEL_LOG_ENABLED:false}
+management.endpoints.access.default=read_only
+management.endpoints.web.exposure.include=health
 management.endpoints.web.path-mapping.health=${MANAGEMENT_ENDPOINTS_WEB_PATH_MAPPING_HEALTH}
 management.endpoints.web.base-path=${MANAGEMENT_ENDPOINTS_WEB_BASE_PATH}
+management.opentelemetry.logging.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/logs
+management.opentelemetry.tracing.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces
+management.otlp.metrics.export.url=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/metrics
 
 nationality.list=${NATIONALITY_LIST}
 
 # Spring MongoDB
-spring.data.mongodb.uri=${MONGODB_URL}
+spring.mongodb.uri=${MONGODB_URL}
 spring.data.mongodb.field-naming-strategy=org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy
 
 # Spring JSON

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -41,7 +41,9 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -81,21 +83,21 @@ class DirectorsControllerImplIT {
     private OfficerService officerService;
     @MockitoBean
     private ApiClientService apiClientService;
-    @Mock
+    @MockitoBean
     private HttpServletRequest request;
-    @Mock
+    @MockitoBean
     private TransactionService transactionService;
-    @Mock
+    @MockitoBean
     AppointmentFullRecordAPI appointmentFullRecordAPI;
-    @Mock
+    @MockitoBean
     OfficerServiceException serviceException;
-    @Mock
+    @MockitoBean
     private ApiClient apiClientMock;
-    @Mock
+    @MockitoBean
     private TransactionsResourceHandler transactionResourceHandlerMock;
-    @Mock
+    @MockitoBean
     private TransactionsGet transactionGetMock;
-    @Mock
+    @MockitoBean
     private ApiResponse<Transaction> apiResponse;
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/DirectorsControllerImplIT.java
@@ -4,7 +4,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/FilingDataControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/FilingDataControllerImplIT.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplIT.java
@@ -36,9 +36,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -94,28 +93,38 @@ class OfficerFilingControllerImplIT {
 
     @MockitoBean
     private TransactionService transactionService;
+
     @MockitoBean
     private OfficerFilingService officerFilingService;
+
     @MockitoBean
     private OfficerFilingMapper filingMapper;
+
     @MockitoBean
     private CompanyProfileService companyProfileService;
+
     @MockitoBean
     private CompanyAppointmentService companyAppointmentService;
+
     @MockitoBean
     private Clock clock;
+
     @MockitoBean
     private Logger logger;
+
     @MockitoBean
     private ApiClientService apiClientService;
 
-    @Mock
+    @MockitoBean
     private ApiClient apiClientMock;
-    @Mock
+
+    @MockitoBean
     private TransactionsResourceHandler transactionResourceHandlerMock;
-    @Mock
+
+    @MockitoBean
     private TransactionsGet transactionGetMock;
-    @Mock
+
+    @MockitoBean
     private ApiResponse<Transaction> apiResponse;
 
     private HttpHeaders httpHeaders;
@@ -124,11 +133,12 @@ class OfficerFilingControllerImplIT {
     private AppointmentFullRecordAPI companyAppointment;
     private Links links;
 
-    @Mock
+    @MockitoBean
     private HttpServletRequest request;
 
     @Autowired
     private MockMvc mockMvc;
+
     @Autowired
     private OfficerFilingControllerImpl testController;
 
@@ -362,7 +372,7 @@ class OfficerFilingControllerImplIT {
                 .andExpect(jsonPath("$.errors[0].error", containsString(
                         "Cannot coerce empty String")))
                 .andExpect(jsonPath("$.errors[0].error_values",
-                        is(Map.of("offset", "line: 1, column: 1", "line", "1", "column", "1"))));
+                        is(Map.of("offset", "byte offset: #0", "line", "1", "column", "1"))));
     }
 
     @Test
@@ -427,7 +437,7 @@ class OfficerFilingControllerImplIT {
                         "JSON parse error: Unexpected end-of-input: expected close marker for "
                                 + "Object")))
                 .andExpect(jsonPath("$.errors[0].error_values",
-                        is(Map.of("offset", "line: 1, column: 109", "line", "1", "column", "109"))));
+                        is(Map.of("offset", "byte offset: #108", "line", "1", "column", "109"))));
     }
 
     @Test
@@ -593,7 +603,7 @@ class OfficerFilingControllerImplIT {
                         "JSON parse error: Cannot deserialize value of type `java.time.LocalDate`"
                                 + " from String \"" + replacementString + "\"")))
                 .andExpect(jsonPath("$.errors[0].error_values",
-                        is(Map.of("offset", "line: 1, column: 97", "line", "1", "column", "97"))));
+                        is(Map.of("offset", "byte offset: #96", "line", "1", "column", "97"))));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.officerfiling.api.controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/OfficerFilingControllerImplValidationIT.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -83,13 +83,13 @@ class OfficerFilingControllerImplValidationIT {
     @MockitoBean
     private ApiClientService apiClientService;
 
-    @Mock
+    @MockitoBean
     private ApiClient apiClientMock;
-    @Mock
+    @MockitoBean
     private TransactionsResourceHandler transactionResourceHandlerMock;
-    @Mock
+    @MockitoBean
     private TransactionsGet transactionGetMock;
-    @Mock
+    @MockitoBean
     private ApiResponse<Transaction> apiResponse;
 
     private HttpHeaders httpHeaders;

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/controller/ValidationStatusControllerImplIT.java
@@ -21,9 +21,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -73,20 +72,20 @@ class ValidationStatusControllerImplIT {
     private CompanyProfileService companyProfileService;
     @MockitoBean
     private CompanyAppointmentService companyAppointmentService;
-    @Mock
+    @MockitoBean
     private ApiClient apiClientMock;
-    @Mock
+    @MockitoBean
     private TransactionsResourceHandler transactionResourceHandlerMock;
-    @Mock
+    @MockitoBean
     private TransactionsGet transactionGetMock;
-    @Mock
+    @MockitoBean
     private ApiResponse<Transaction> apiResponse;
 
     private HttpHeaders httpHeaders;
     private CompanyProfileApi companyProfileApi;
     private AppointmentFullRecordAPI companyAppointment;
 
-    @Mock
+    @MockitoBean
     private Clock clock;
 
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/enumerations/ConstantsConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/enumerations/ConstantsConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 import uk.gov.companieshouse.officerfiling.api.config.enumerations.ConstantsEnumerationsConfig;
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/enumerations/OfficerFilingEnumerationsConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/enumerations/OfficerFilingEnumerationsConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 import uk.gov.companieshouse.officerfiling.api.config.enumerations.OfficerFilingEnumerationsConfig;
 

--- a/src/test/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officerfiling/api/error/RestExceptionHandlerTest.java
@@ -9,10 +9,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -32,6 +28,10 @@ import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.validation.FieldError;
 import org.springframework.web.context.request.ServletWebRequest;
+import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.exc.MismatchedInputException;
 import uk.gov.companieshouse.api.error.ApiError;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.officerfiling.api.exception.ResourceNotFoundException;
@@ -53,14 +53,14 @@ class RestExceptionHandlerTest {
     @Mock
     private MismatchedInputException mismatchedInputException;
     @Mock
-    private JsonParseException jsonParseException;
+    private StreamReadException streamReadException;
     @Mock
     private Logger logger;
 
     private MockHttpServletRequest servletRequest;
 
     @Mock
-    private JsonMappingException.Reference mappingReference;
+    private DatabindException.Reference mappingReference;
 
     @BeforeEach
     void setUp() {
@@ -104,9 +104,9 @@ class RestExceptionHandlerTest {
         final var message = new MockHttpInputMessage("{]".getBytes());
 
         when(mismatchedInputException.getMessage()).thenReturn(msg);
-        when(mismatchedInputException.getLocation()).thenReturn(new JsonLocation(null, 100, 3, 7));
+        when(mismatchedInputException.getLocation()).thenReturn(new TokenStreamLocation(null, 100, 3, 7));
         when(mismatchedInputException.getPath()).thenReturn(List.of(mappingReference));
-        when(mappingReference.getFieldName()).thenReturn("resigned_on");
+        when(mappingReference.getPropertyName()).thenReturn("resigned_on");
 
         final var exceptionMessage =
                 new HttpMessageNotReadableException(msg, mismatchedInputException, message);
@@ -117,7 +117,7 @@ class RestExceptionHandlerTest {
         final var expectedError =
                 new ApiError("JSON parse error: " + msg, "$..resigned_on", "json-path",
                         "ch:validation");
-        expectedError.addErrorValue("offset", "line: 3, column: 7");
+        expectedError.addErrorValue("offset", "byte offset: #UNKNOWN");
         expectedError.addErrorValue("line", "3");
         expectedError.addErrorValue("column", "7");
         final var actualError = Objects.requireNonNull(apiErrors).getErrors().iterator().next();
@@ -133,11 +133,11 @@ class RestExceptionHandlerTest {
         final var message =
                 new MockHttpInputMessage(TM01_FRAGMENT.replaceAll("2022", "ABC").getBytes());
 
-        when(jsonParseException.getMessage()).thenReturn(msg);
-        when(jsonParseException.getLocation()).thenReturn(new JsonLocation(null, 100, 3, 7));
+        when(streamReadException.getMessage()).thenReturn(msg);
+        when(streamReadException.getLocation()).thenReturn(new TokenStreamLocation(null, 100, 3, 7));
 
         final var exceptionMessage =
-                new HttpMessageNotReadableException(msg, jsonParseException, message);
+                new HttpMessageNotReadableException(msg, streamReadException, message);
 
         final var response =
                 testExceptionHandler.handleHttpMessageNotReadable(exceptionMessage, headers,
@@ -146,7 +146,7 @@ class RestExceptionHandlerTest {
         final var apiErrors = (ApiErrors) response.getBody();
         final var expectedError =
                 new ApiError("JSON parse error: " + msg, "$", "json-path", "ch:validation");
-        expectedError.addErrorValue("offset", "line: 3, column: 7");
+        expectedError.addErrorValue("offset", "byte offset: #UNKNOWN");
         expectedError.addErrorValue("line", "3");
         expectedError.addErrorValue("column", "7");
         final var actualError = Objects.requireNonNull(apiErrors).getErrors().iterator().next();
@@ -162,10 +162,10 @@ class RestExceptionHandlerTest {
         final var message =
                 new MockHttpInputMessage(TM01_FRAGMENT.replaceAll("2022", "ABC").getBytes());
 
-        when(jsonParseException.getMessage()).thenReturn(msg);
+        when(streamReadException.getMessage()).thenReturn(msg);
 
         final var exceptionMessage =
-                new HttpMessageNotReadableException(msg, jsonParseException, message);
+                new HttpMessageNotReadableException(msg, streamReadException, message);
 
         final var response =
                 testExceptionHandler.handleHttpMessageNotReadable(exceptionMessage, headers,


### PR DESCRIPTION
## Overview
This branch updates the service to Spring Boot 4.x compatible dependency baselines, refreshes core Companies House libraries, and switches OpenTelemetry integration to the Spring Boot 4 path.

## Version upgrades
| Component | Previous | New |
|---|---:|---:|
| `companies-house-parent` | `2.1.12` | `2.1.14` |
| Spring Boot BOM (`spring-boot-dependencies`) | `3.5.14` | `4.1.0` |
| `jib-maven-plugin` | `3.4.6` | `3.5.1` |
| `maven-compiler-plugin` | `3.14.0` | `3.15.0` |
| `maven-surefire-plugin` | `3.5.3` | `3.5.6` |
| `maven-failsafe-plugin` | `3.5.3` | `3.5.6` |
| `equalsverifier` | `4.0.3` | `4.5` |
| OpenTelemetry BOM | `2.24.0` | `2.29.0` |
| `structured-logging` | `3.0.51` | `3.0.57` |
| `private-api-sdk-java` | `4.0.476` | `6.0.33` |
| `api-sdk-manager-java-library` | `3.0.16` | `3.0.23` |
| `api-security-java` | `2.0.24` | `2.0.27` |
| `api-helper-java` | `3.0.3` | `3.0.4` |

## Added dependencies
- `org.springframework.boot:spring-boot-starter-opentelemetry`
- `io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:${opentelemetry.version}-alpha`
- `org.springframework.boot:spring-boot-starter-webmvc-test`
- `org.jetbrains.kotlin:kotlin-bom:2.3.21` (dependencyManagement)

## Removed dependencies / explicit overrides
- `io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter`
- Explicit `org.jetbrains.kotlin:kotlin-stdlib:2.2.21` pin
- Explicit `org.apache.commons:commons-lang3:3.18.0` override
- Explicit JUnit dependencies (`junit-jupiter-api`, `junit-jupiter-engine`, `junit-platform-launcher`)
- Optional runtime `spring-boot-devtools`
- Explicit CVE/transitive override pins removed from dependencyManagement:
  - `org.apache.logging.log4j:log4j-api:2.25.4`
  - `org.apache.logging.log4j:log4j-to-slf4j:2.25.4`
  - `io.grpc:grpc-api:1.81.0`
  - `org.apache.tomcat.embed:tomcat-embed-core:10.1.55`
  - `org.apache.tomcat.embed:tomcat-embed-websocket:10.1.55`

## Related configuration changes (dependency-driven)
- Actuator/OpenTelemetry properties migrated to the newer management key space.
- Mongo URI property updated from `spring.data.mongodb.uri` to `spring.mongodb.uri`.

## Code changes required for compatibility
- **Jackson package migration for Spring Boot 4 stack**:
  - Replaced `com.fasterxml.jackson.*` imports with `tools.jackson.*` in production and test code where JSON parsing/mapping is handled.
  - Updated exception handling types and APIs (for example `JsonProcessingException` → `JacksonException`, `JsonLocation` → `TokenStreamLocation`, mapping reference accessors).
- **JSON error response behavior updates**:
  - `RestExceptionHandler` now reads location/path details from the new Jackson exception model.
  - Tests were updated for the new offset text format (for example `byte offset: #...`).
- **ObjectMapper/date-time handling refactor**:
  - Replaced `JavaTimeModule` registration patterns with `JsonMapper` configuration using `DateTimeFeature.WRITE_DATES_WITH_ZONE_ID`.
  - Applied in merge/mapping paths (`OfficerFilingServiceImpl`, `MapHelper`) to preserve expected date/time serialization behavior.
- **Map helper hardening**:
  - `MapHelper` now caches `ObjectMapper` instances per naming strategy (thread-safe `ConcurrentHashMap`) rather than mutating a shared mapper.
  - Added null-checking for naming strategy input.
- **Web MVC test framework package updates**:
  - Updated `@WebMvcTest` import path to the Spring Boot 4 location.
  - Replaced several plain `@Mock` fields in MVC tests with `@MockitoBean` so dependencies are correctly injected into the Spring test context.
